### PR TITLE
Big_query.Jobs.query ~dry_run

### DIFF
--- a/src/big_query.ml
+++ b/src/big_query.ml
@@ -475,6 +475,7 @@ module Jobs = struct
   type query_request =
     { kind : string
     ; query : string
+    ; dry_run : bool option [@key "dryRun"] [@default None]
     ; use_legacy_sql : bool [@key "useLegacySql"]
     ; location : string option [@default None]
     ; query_parameters : Param.query_parameter list [@key "queryParameters"]
@@ -823,6 +824,7 @@ module Jobs = struct
 
   let query
       ?project_id
+      ?dry_run
       ?(use_legacy_sql = false)
       ?(params = [])
       ?location
@@ -840,6 +842,7 @@ module Jobs = struct
     let request =
       { kind = "bigquery#queryRequest"
       ; query = q
+      ; dry_run
       ; use_legacy_sql
       ; location
       ; parameter_mode

--- a/src/big_query.ml
+++ b/src/big_query.ml
@@ -672,6 +672,21 @@ module Jobs = struct
          ] )
 
 
+  let pp_query_response_data fmt (data : query_response_data) =
+    Format.fprintf
+      fmt
+      "Response: total_bytes_processed=%s cache_hit=%b rows=%d%s%s"
+      data.total_bytes_processed
+      data.cache_hit
+      (CCList.length data.rows)
+      ( data.total_rows
+      |> CCOpt.map_or ~default:"" (fun t -> Printf.sprintf " total_rows=%s" t)
+      )
+      ( data.num_dml_affected_rows
+      |> CCOpt.map_or ~default:"" (fun t ->
+             Printf.sprintf " num_dml_affected_rows=%s" t ) )
+
+
   let pp_query_response fmt (query_response : query_response) =
     match query_response.job_complete with
     | None ->
@@ -682,18 +697,10 @@ module Jobs = struct
     | Some data ->
         Format.fprintf
           fmt
-          "Response: job_id=%s total_bytes_processed=%s cache_hit=%b \
-           rows=%d%s%s"
+          "Response: job_id=%s %a"
           query_response.job_reference.job_id
-          data.total_bytes_processed
-          data.cache_hit
-          (CCList.length data.rows)
-          ( data.total_rows
-          |> CCOpt.map_or ~default:"" (fun t ->
-                 Printf.sprintf " total_rows=%s" t ) )
-          ( data.num_dml_affected_rows
-          |> CCOpt.map_or ~default:"" (fun t ->
-                 Printf.sprintf " num_dml_affected_rows=%s" t ) )
+          pp_query_response_data
+          data
 
 
   type query_response_complete =

--- a/src/big_query.mli
+++ b/src/big_query.mli
@@ -178,6 +178,7 @@ module Jobs : sig
 
   val query :
        ?project_id:string
+    -> ?dry_run:bool
     -> ?use_legacy_sql:bool
     -> ?params:Param.query_parameter list
     -> ?location:string

--- a/src/big_query.mli
+++ b/src/big_query.mli
@@ -136,7 +136,7 @@ module Jobs : sig
   end
 
   type job_reference =
-    { job_id : string
+    { job_id : string option
     ; project_id : string
     ; location : string
     }

--- a/src/big_query.mli
+++ b/src/big_query.mli
@@ -163,6 +163,8 @@ module Jobs : sig
     ; cache_hit : bool
     }
 
+  val pp_query_response_data : Format.formatter -> query_response_data -> unit
+
   (** Type of query responses. We may or may not have the data, depending on
       whether the job completed within the timeout.
 


### PR DESCRIPTION
* Allow setting `~dry_run:true` in query requests.
* Use `OCAML_GCLOUD_BQ_USE_GZIP=false` to disable use of gzip and see the response JSON in debug logs.