### PR TITLE
Add optional `places` param to ROUND function

### DIFF
--- a/src-shared/big_query_dsl.ml
+++ b/src-shared/big_query_dsl.ml
@@ -239,7 +239,7 @@ module rec Expression : sig
 
   val ceil : t -> t
 
-  val round : t -> t
+  val round : ?places:t -> t -> t
 
   val mod_ : t -> t -> t
 
@@ -1106,7 +1106,7 @@ end = struct
 
   let ceil e = make_fn "CEIL" [ e ]
 
-  let round e = make_fn "ROUND" [ e ]
+  let round ?places e = make_fn "ROUND" (match places with | Some x-> [e; x ] | None-> [ e ])
 
   let mod_ e1 e2 = make_fn "MOD" [ e1; e2 ]
 


### PR DESCRIPTION
What
----
Change the signature of `round` to be `val round : ?places:t -> t -> t`

Why
---

Round takes an optional second argument that can be used to specify how many decimal places to round to. Without this parameter `round` will just round to the nearest decimal

`select round(0.314), round(0.314,2)` will return `(0.0, 0.31)`

https://cloud.google.com/bigquery/docs/reference/standard-sql/mathematical_functions#round