### PR TITLE
refactor: auth and project-id detection

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,7 @@
           opamScope = (on.buildOpamProject'
             {
               repos = [ opam-repository ];
+              resolveArgs.with-test = true;
               recursive = true;
               overlays = on.__overlays ++ [
                 (final: prev:

--- a/src/auth.ml
+++ b/src/auth.ml
@@ -5,6 +5,8 @@ let src = Logs.Src.create "gcloud.auth"
 
 module L = (val Logs_lwt.src_log src)
 
+let ok = Lwt_result.ok
+
 module Environment_vars = struct
   let google_application_credentials = "GOOGLE_APPLICATION_CREDENTIALS"
 
@@ -89,7 +91,7 @@ module Compute_engine = struct
       Cohttp_lwt_unix.Client.get uri ~headers:metadata_headers
       >>= fun (resp, body) ->
       match Cohttp.Response.status resp with
-      | `OK -> Cohttp_lwt.Body.to_string body |> Lwt_result.ok
+      | `OK -> Cohttp_lwt.Body.to_string body |> ok
       | status -> `Bad_GCE_metadata_response status |> Lwt_result.fail
   end
 end
@@ -102,6 +104,7 @@ module Cloud_sdk = struct
         let open Lwt.Infix in
         process_in#status >>= fun _status ->
         Lwt_io.read process_in#stdout >|= String.trim)
+    |> Lwt.map CCOption.some |> ok
 end
 
 type error =
@@ -275,7 +278,6 @@ type token_info = {
   token : Access_token.t;
   created_at : float;
   scopes : string list;
-  project_id : string;
 }
 
 let token_info_mvar : token_info option Lwt_mvar.t = Lwt_mvar.create None
@@ -397,9 +399,7 @@ let access_token_of_credentials (scopes : string list)
           ("grant_type", [ "refresh_token" ]);
         ]
       in
-      let* res =
-        Cohttp_lwt_unix.Client.post_form token_uri ~params |> Lwt_result.ok
-      in
+      let* res = Cohttp_lwt_unix.Client.post_form token_uri ~params |> ok in
       access_token_of_response ~of_json:access_token_of_json res
   | Service_account c -> (
       let now = Unix.time () in
@@ -435,7 +435,7 @@ let access_token_of_credentials (scopes : string list)
           in
           let* res =
             Cohttp_lwt_unix.Client.post_form (Uri.of_string c.token_uri) ~params
-            |> Lwt_result.ok
+            |> ok
           in
           access_token_of_response ~of_json:access_token_of_json res
       | _ -> Lwt_result.fail (`Bad_credentials_priv_key "Not RSA key"))
@@ -448,7 +448,7 @@ let access_token_of_credentials (scopes : string list)
       let* res =
         Cohttp_lwt_unix.Client.get uri
           ~headers:Compute_engine.Metadata.metadata_headers
-        |> Lwt_result.ok
+        |> ok
       in
       access_token_of_response ~of_json:access_token_of_json res
   | External_account (c : External_account_credentials.t) -> (
@@ -461,22 +461,18 @@ let access_token_of_credentials (scopes : string list)
       *)
       let scopes = [ Scopes.iam ] @ scopes in
       let* res =
-        let* () =
-          L.debug (fun m -> m "Requesting subject token") |> Lwt_result.ok
-        in
+        let* () = L.debug (fun m -> m "Requesting subject token") |> ok in
         let* subject_token =
           let subject_token_uri = Uri.of_string c.credential_source.url in
           let* resp =
             Cohttp_lwt_unix.Client.get
               ~headers:(Cohttp.Header.of_list c.credential_source.headers)
               subject_token_uri
-            |> Lwt_result.ok
+            |> ok
           in
           External_account_credentials.subject_token_of_response c resp
         in
-        let* () =
-          L.debug (fun m -> m "Performing token exchange") |> Lwt_result.ok
-        in
+        let* () = L.debug (fun m -> m "Performing token exchange") |> ok in
         let token_uri = Uri.of_string c.token_url in
         let params =
           `Assoc
@@ -492,9 +488,7 @@ let access_token_of_credentials (scopes : string list)
             ]
         in
         let body = Cohttp_lwt.Body.of_string (Yojson.Basic.to_string params) in
-        let* res =
-          Cohttp_lwt_unix.Client.post token_uri ~body |> Lwt_result.ok
-        in
+        let* res = Cohttp_lwt_unix.Client.post token_uri ~body |> ok in
         Lwt_result.return res
       in
       match c.service_account_impersonation_url with
@@ -502,7 +496,7 @@ let access_token_of_credentials (scopes : string list)
       | Some sac ->
           let* () =
             L.debug (fun m -> m "attempting to impersonate service account")
-            |> Lwt_result.ok
+            |> ok
           in
           let* initial_access_token = access_token_of_response res in
           let headers =
@@ -521,12 +515,8 @@ let access_token_of_credentials (scopes : string list)
             Cohttp_lwt.Body.of_string (Yojson.Basic.to_string params)
           in
           let uri = Uri.of_string sac in
-          let* () =
-            L.debug (fun m -> m "POST %a" Uri.pp_hum uri) |> Lwt_result.ok
-          in
-          let* res =
-            Cohttp_lwt_unix.Client.post uri ~headers ~body |> Lwt_result.ok
-          in
+          let* () = L.debug (fun m -> m "POST %a" Uri.pp_hum uri) |> ok in
+          let* res = Cohttp_lwt_unix.Client.post uri ~headers ~body |> ok in
           let access_token_of_json (json : Yojson.Basic.t) :
               (Access_token.t, [> error ]) result =
             (* has a slightly different format from the access token in the other responses:
@@ -563,18 +553,6 @@ let access_token_of_credentials (scopes : string list)
           in
           access_token_of_response ~of_json:access_token_of_json res)
 
-let project_id_of_credentials (credentials : credentials) : string option =
-  match credentials with
-  | Service_account { project_id; _ } -> Some project_id
-  | Authorized_user _ | External_account _ | GCE_metadata -> None
-
-let discover_project_id (credentials : credentials) : string option =
-  CCOption.choice
-    [
-      Sys.getenv_opt Environment_vars.google_project_id;
-      project_id_of_credentials credentials;
-    ]
-
 let discover_credentials_with (discovery_mode : discovery_mode) =
   let open Lwt.Infix in
   L.debug (fun m ->
@@ -590,38 +568,17 @@ let discover_credentials_with (discovery_mode : discovery_mode) =
       | Some credentials_file ->
           let open Lwt_result.Syntax in
           let* credentials = credentials_of_file credentials_file in
-          let* () =
-            L.debug (fun m -> m "Trying to find project id:") |> Lwt_result.ok
-          in
-
-          let* project_id =
-            discover_project_id credentials
-            |> CCOption.to_result `No_project_id
-            |> Lwt.return
-          in
-          Lwt_result.return (credentials, project_id))
+          Lwt_result.return credentials)
   | Discover_credentials_json_from_env -> (
       let credentials_json =
         Sys.getenv_opt Environment_vars.google_application_credentials_json
       in
       match credentials_json with
       | None -> Lwt.return_error `No_credentials
-      | Some json_str ->
-          let open Lwt_result.Infix in
-          credentials_of_string json_str |> Lwt.return >>= fun credentials ->
-          discover_project_id credentials
-          |> CCOption.to_result `No_project_id
-          |> Lwt.return
-          >>= fun project_id -> Lwt_result.return (credentials, project_id))
-  | Discover_credentials_from_cloud_sdk_path -> (
+      | Some json_str -> credentials_of_string json_str |> Lwt.return)
+  | Discover_credentials_from_cloud_sdk_path ->
       let open Lwt_result.Infix in
       credentials_of_file Paths.application_default_credentials
-      >>= fun credentials ->
-      match discover_project_id credentials with
-      | Some project_id -> Lwt_result.return (credentials, project_id)
-      | None ->
-          Cloud_sdk.get_project_id () |> Lwt_result.ok >>= fun project_id ->
-          Lwt_result.return (credentials, project_id))
   | Discover_credentials_from_gce_metadata ->
       let ping =
         Lwt.catch
@@ -630,13 +587,7 @@ let discover_credentials_with (discovery_mode : discovery_mode) =
             match Cohttp.Response.status resp with
             | `OK when Compute_engine.Metadata.response_has_metadata_header resp
               ->
-                let open Lwt_result.Infix in
-                let credentials = GCE_metadata in
-                let project_id = discover_project_id credentials in
-                (match project_id with
-                | Some project_id -> Lwt_result.return project_id
-                | None -> Compute_engine.Metadata.get_project_id ())
-                >>= fun project_id -> Lwt.return_ok (credentials, project_id)
+                Lwt_result.return GCE_metadata
             | _ -> Lwt.return_error `No_credentials)
           (fun _exn -> Lwt.return_error `No_credentials)
       in
@@ -656,7 +607,7 @@ let rec first_ok ~(error : 'e) (fs : (unit -> ('a, 'e) result Lwt.t) list) :
       | Ok x -> Lwt.return_ok x
       | Error error -> first_ok ~error fs)
 
-let discover_credentials () : (credentials * string, [> error ]) Lwt_result.t =
+let discover_credentials () : (credentials, [> error ]) Lwt_result.t =
   [
     Discover_credentials_path_from_env;
     Discover_credentials_json_from_env;
@@ -690,23 +641,14 @@ let get_access_token ?(scopes : string list = []) () :
     (token_info, [> error ]) Lwt_result.t =
   let get_new_access_token scopes =
     let open Lwt_result.Syntax in
-    let* credentials, project_id = discover_credentials () in
+    let* credentials = discover_credentials () in
     let* access_token = access_token_of_credentials scopes credentials in
-    let+ () =
-      L.info (fun m -> m "Authenticated OK (project: %s)" project_id)
-      |> Lwt_result.ok
-    in
+    let+ () = L.info (fun m -> m "Authenticated OK!") |> ok in
     let scopes =
       CCList.union ~eq:String.equal scopes
         access_token.additional_refresh_scopes
     in
-    {
-      credentials;
-      token = access_token;
-      created_at = Unix.time ();
-      scopes;
-      project_id;
-    }
+    { credentials; token = access_token; created_at = Unix.time (); scopes }
   in
   let has_requested_scopes token_info =
     CCList.subset ~eq:String.equal scopes token_info.scopes
@@ -737,7 +679,33 @@ let get_access_token ?(scopes : string list = []) () :
   let* () = Lwt_mvar.put token_info_mvar (CCResult.to_opt token_info_result) in
   Lwt.return token_info_result
 
-let get_project_id (scopes : string list) =
-  let open Lwt_result.Infix in
-  get_access_token ~scopes () >>= fun token_info ->
-  Lwt.return_ok token_info.project_id
+let project_id_of_credentials (credentials : credentials) : string option =
+  match credentials with
+  | Service_account { project_id; _ } -> Some project_id
+  | Authorized_user _ | External_account _ | GCE_metadata -> None
+
+(** [project_id] optional arg is a convenience where project_id is optionally
+    available for the caller (e.g. a CLI entrypoint where --project-id X may or may
+    not have been passed) *)
+let get_project_id ?project_id (scopes : string list) =
+  let open Lwt_result.Syntax in
+  let static_project_id =
+    CCOption.choice
+      [ project_id; Sys.getenv_opt Environment_vars.google_project_id ]
+  in
+  match static_project_id with
+  | Some project_id -> Lwt_result.return project_id
+  | None -> (
+      let* token_info = get_access_token ~scopes () in
+      let* project_id =
+        match token_info.credentials with
+        | Service_account { project_id; _ } ->
+            Lwt_result.return (Some project_id)
+        | GCE_metadata ->
+            Compute_engine.Metadata.get_project_id ()
+            |> Lwt_result.map CCOption.some
+        | _ -> Cloud_sdk.get_project_id ()
+      in
+      match project_id with
+      | None -> Lwt_result.fail `No_project_id
+      | Some p -> Lwt_result.return p)

--- a/src/auth.ml
+++ b/src/auth.ml
@@ -113,7 +113,6 @@ type error =
   | `Bad_credentials_priv_key of string
   | `Jwt_signing_error of string
   | `No_credentials
-  | `No_project_id
   | `Bad_subject_token_response of Cohttp.Response.t * string
   | Compute_engine.Metadata.error ]
 
@@ -133,9 +132,6 @@ let pp_error fmt (error : error) =
       Format.fprintf fmt
         "Unexpected response (%s) while fetching subject token: %s" status_str
         body_str
-  | `No_project_id ->
-      Format.fprintf fmt "Could not discover the project ID (try setting %s)"
-        Environment_vars.google_project_id
   | #Compute_engine.Metadata.error as e ->
       Compute_engine.Metadata.pp_error fmt e
 

--- a/src/big_query.ml
+++ b/src/big_query.ml
@@ -67,13 +67,8 @@ end
 module Datasets = struct
   let get ?project_id ~dataset_id () : (string, [> Error.t ]) Lwt_result.t =
     let open Lwt_result.Infix in
-    Auth.get_access_token ~scopes:[ Scopes.bigquery ] ()
-    |> Lwt_result.map_error (fun e -> `Gcloud_auth_error e)
-    >>= fun token_info ->
-    let project_id =
-      project_id |> CCOption.get_or ~default:token_info.project_id
-    in
-
+    Common.get_access_token ~scopes:[ Scopes.bigquery ] () >>= fun token_info ->
+    Common.get_project_id ?project_id ~token_info () >>= fun project_id ->
     Lwt.catch
       (fun () ->
         let uri =
@@ -99,13 +94,8 @@ module Datasets = struct
 
   let list ?project_id () : (string, [> Error.t ]) Lwt_result.t =
     let open Lwt_result.Infix in
-    Auth.get_access_token ~scopes:[ Scopes.bigquery ] ()
-    |> Lwt_result.map_error (fun e -> `Gcloud_auth_error e)
-    >>= fun token_info ->
-    let project_id =
-      project_id |> CCOption.get_or ~default:token_info.project_id
-    in
-
+    Common.get_access_token ~scopes:[ Scopes.bigquery ] () >>= fun token_info ->
+    Common.get_project_id ?project_id ~token_info () >>= fun project_id ->
     Lwt.catch
       (fun () ->
         let uri =
@@ -149,13 +139,9 @@ module Datasets = struct
     let list ?project_id ?max_results ?page_token ~dataset_id () :
         (resp, [> Error.t ]) Lwt_result.t =
       let open Lwt_result.Infix in
-      Auth.get_access_token ~scopes:[ Scopes.bigquery ] ()
-      |> Lwt_result.map_error (fun e -> `Gcloud_auth_error e)
+      Common.get_access_token ~scopes:[ Scopes.bigquery ] ()
       >>= fun token_info ->
-      let project_id =
-        project_id |> CCOption.get_or ~default:token_info.project_id
-      in
-
+      Common.get_project_id ?project_id ~token_info () >>= fun project_id ->
       Lwt.catch
         (fun () ->
           let uri =
@@ -710,13 +696,8 @@ module Jobs = struct
     in
 
     let open Lwt_result.Infix in
-    Auth.get_access_token ~scopes:[ Scopes.bigquery ] ()
-    |> Lwt_result.map_error (fun e -> `Gcloud_auth_error e)
-    >>= fun token_info ->
-    let project_id =
-      project_id |> CCOption.get_or ~default:token_info.project_id
-    in
-
+    Common.get_access_token ~scopes:[ Scopes.bigquery ] () >>= fun token_info ->
+    Common.get_project_id ?project_id ~token_info () >>= fun project_id ->
     let use_gzip = use_gzip () in
 
     Lwt.catch

--- a/src/common.ml
+++ b/src/common.ml
@@ -1,3 +1,7 @@
+let src = Logs.Src.create "gcloud.common"
+
+module Log = (val Logs.src_log src)
+
 module Cloud_sdk = struct
   let get_project_id () =
     let open Lwt.Syntax in
@@ -5,15 +9,14 @@ module Cloud_sdk = struct
       Lwt_io.(
         with_file ~mode:input Auth.Paths.active_config (fun ic -> read_line ic))
     in
+    let active_config_path = Auth.Paths.(config ~active_config_name) in
     let* active_config =
-      Lwt_io.(
-        with_file ~mode:input
-          Auth.Paths.(config ~active_config_name)
-          (fun ic -> read ic))
+      Lwt_io.(with_file ~mode:input active_config_path (fun ic -> read ic))
     in
     CCString.lines active_config
     |> CCList.find_map (CCString.Split.left ~by:"project = ")
-    |> CCOption.map (fun (_pre, v) -> v)
+    |> CCOption.map (fun (_pre, v) ->
+           (v, Format.asprintf "Cloud SDK Config: %s" active_config_path))
     |> Lwt_result.return
 end
 
@@ -28,19 +31,25 @@ let project_id_of_credentials (credentials : Auth.credentials) : string option =
     not have been passed *)
 let get_project_id ?project_id ~token_info () =
   let open Lwt_result.Syntax in
+  let m label x = CCOption.map (fun pid -> (pid, label)) x in
   match
     CCOption.choice
       [
-        project_id;
-        Sys.getenv_opt Auth.Environment_vars.google_project_id;
-        project_id_of_credentials token_info.Auth.credentials;
+        project_id |> m "Explicitly passed";
+        Sys.getenv_opt Auth.Environment_vars.google_project_id
+        |> m "Environment variable";
+        project_id_of_credentials token_info.Auth.credentials |> m "Credentials";
       ]
   with
-  | Some project_id -> Lwt_result.return project_id
+  | Some (project_id, label) ->
+      let () = Log.debug (fun m -> m "Using project_id from: %s" label) in
+      Lwt_result.return project_id
   | None -> (
       let* pid = Cloud_sdk.get_project_id () in
       match pid with
-      | Some project_id -> Lwt_result.return project_id
+      | Some (project_id, label) ->
+          let () = Log.debug (fun m -> m "Using project_id from: %s" label) in
+          Lwt_result.return project_id
       | None -> Lwt_result.fail `No_project_id)
 
 let get_access_token ?scopes () : (Auth.token_info, [> Error.t ]) Lwt_result.t =

--- a/src/common.ml
+++ b/src/common.ml
@@ -42,3 +42,7 @@ let get_project_id ?project_id ~token_info () =
       match pid with
       | Some project_id -> Lwt_result.return project_id
       | None -> Lwt_result.fail `No_project_id)
+
+let get_access_token ?scopes () : (Auth.token_info, [> Error.t ]) Lwt_result.t =
+  Auth.get_access_token ?scopes ()
+  |> Lwt_result.map_error (fun e -> `Gcloud_auth_error e)

--- a/src/common.ml
+++ b/src/common.ml
@@ -1,0 +1,44 @@
+module Cloud_sdk = struct
+  let get_project_id () =
+    let open Lwt.Syntax in
+    let* active_config_name =
+      Lwt_io.(
+        with_file ~mode:input Auth.Paths.active_config (fun ic -> read_line ic))
+    in
+    let* active_config =
+      Lwt_io.(
+        with_file ~mode:input
+          Auth.Paths.(config ~active_config_name)
+          (fun ic -> read ic))
+    in
+    CCString.lines active_config
+    |> CCList.find_map (CCString.Split.left ~by:"project = ")
+    |> CCOption.map (fun (_pre, v) -> v)
+    |> Lwt_result.return
+end
+
+let project_id_of_credentials (credentials : Auth.credentials) : string option =
+  match credentials with
+  | Service_account { project_id; _ } | GCE_metadata { project_id } ->
+      Some project_id
+  | Authorized_user _ | External_account _ -> None
+
+(** [project_id] optional arg is a convenience where project_id is optionally
+    available for the caller, e.g. a CLI entrypoint where --project-id X may or may
+    not have been passed *)
+let get_project_id ?project_id ~token_info () =
+  let open Lwt_result.Syntax in
+  match
+    CCOption.choice
+      [
+        project_id;
+        Sys.getenv_opt Auth.Environment_vars.google_project_id;
+        project_id_of_credentials token_info.Auth.credentials;
+      ]
+  with
+  | Some project_id -> Lwt_result.return project_id
+  | None -> (
+      let* pid = Cloud_sdk.get_project_id () in
+      match pid with
+      | Some project_id -> Lwt_result.return project_id
+      | None -> Lwt_result.fail `No_project_id)

--- a/src/container.ml
+++ b/src/container.ml
@@ -32,19 +32,19 @@ module Projects = struct
 
       [@@@warning "+39"]
 
-      let get ~(project : string) ~(location : string) ~(cluster : string) :
+      let get ?project_id ~(location : string) ~(cluster : string) () :
           (t, [> Error.t ]) Lwt_result.t =
         let open Lwt_result.Infix in
-        Auth.get_access_token ~scopes:[ Scopes.cloud_platform ] ()
-        |> Lwt_result.map_error (fun e -> `Gcloud_auth_error e)
+        Common.get_access_token ~scopes:[ Scopes.cloud_platform ] ()
         >>= fun token_info ->
+        Common.get_project_id ?project_id ~token_info () >>= fun project_id ->
         Lwt.catch
           (fun () ->
             let uri =
               Uri.make () ~scheme:"https" ~host:"container.googleapis.com"
                 ~path:
                   (Printf.sprintf "v1beta1/projects/%s/locations/%s/clusters/%s"
-                     project location cluster)
+                     project_id location cluster)
             in
             let headers =
               Cohttp.Header.of_list

--- a/src/error.ml
+++ b/src/error.ml
@@ -28,6 +28,7 @@ type t =
   | `Json_parse_error of string * string (* error, raw json *)
   | `Json_transform_error of string * Yojson.Safe.t (* error, raw json *)
   | `Network_error of exn
+  | `No_project_id
   | `Msg of string ]
 
 let pp fmt (error : t) =
@@ -49,6 +50,9 @@ let pp fmt (error : t) =
         (Yojson.Safe.to_string json_str)
   | `Network_error exn ->
       Format.fprintf fmt "Network error: %s" (Printexc.to_string exn)
+  | `No_project_id ->
+      Format.fprintf fmt "Could not discover the project ID (try setting %s)"
+        Auth.Environment_vars.google_project_id
   | `Msg s -> Format.fprintf fmt "Msg: %s" s
 
 let parse_body_json ?(gzipped = false)

--- a/src/kms.ml
+++ b/src/kms.ml
@@ -6,12 +6,12 @@ module V1 = struct
   module Locations = struct
     module KeyRings = struct
       module CryptoKeys = struct
-        let decrypt ~location ~key_ring ~crypto_key ciphertext :
+        let decrypt ?project_id ~location ~key_ring ~crypto_key ciphertext :
             (string, [> Error.t ]) Lwt_result.t =
           let open Lwt_result.Infix in
-          Auth.get_access_token ~scopes:[ Scopes.cloudkms ] ()
-          |> Lwt_result.map_error (fun e -> `Gcloud_auth_error e)
+          Common.get_access_token ~scopes:[ Scopes.cloudkms ] ()
           >>= fun token_info ->
+          Common.get_project_id ?project_id ~token_info () >>= fun project_id ->
           Lwt.catch
             (fun () ->
               let uri =
@@ -19,7 +19,7 @@ module V1 = struct
                   ~path:
                     (Printf.sprintf
                        "v1/projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s:decrypt"
-                       token_info.project_id location key_ring crypto_key)
+                       project_id location key_ring crypto_key)
               in
               let b64_encoded =
                 Base64.encode_exn ~alphabet:Base64.uri_safe_alphabet ciphertext

--- a/src/kms.mli
+++ b/src/kms.mli
@@ -7,6 +7,7 @@ module V1 : sig
     module KeyRings : sig
       module CryptoKeys : sig
         val decrypt :
+          ?project_id:string ->
           location:string ->
           key_ring:string ->
           crypto_key:string ->

--- a/src/pub_sub.ml
+++ b/src/pub_sub.ml
@@ -10,13 +10,8 @@ module Subscriptions = struct
   let acknowledge ?project_id ~subscription_id ~ids () :
       (unit, [> Error.t ]) Lwt_result.t =
     let open Lwt_result.Infix in
-    Auth.get_access_token ~scopes:[ Scopes.pubsub ] ()
-    |> Lwt_result.map_error (fun e -> `Gcloud_auth_error e)
-    >>= fun token_info ->
-    let project_id =
-      project_id |> CCOption.get_or ~default:token_info.project_id
-    in
-
+    Common.get_access_token ~scopes:[ Scopes.pubsub ] () >>= fun token_info ->
+    Common.get_project_id ?project_id ~token_info () >>= fun project_id ->
     let request = { ackIds = ids } in
 
     Lwt.catch
@@ -70,13 +65,8 @@ module Subscriptions = struct
   let pull ?project_id ~subscription_id ~max_messages
       ?(return_immediately = true) () =
     let open Lwt_result.Infix in
-    Auth.get_access_token ~scopes:[ Scopes.pubsub ] ()
-    |> Lwt_result.map_error (fun e -> `Gcloud_auth_error e)
-    >>= fun token_info ->
-    let project_id =
-      project_id |> CCOption.get_or ~default:token_info.project_id
-    in
-
+    Common.get_access_token ~scopes:[ Scopes.pubsub ] () >>= fun token_info ->
+    Common.get_project_id ?project_id ~token_info () >>= fun project_id ->
     let request =
       { maxMessages = max_messages; returnImmediately = return_immediately }
     in

--- a/src/storage.ml
+++ b/src/storage.ml
@@ -6,8 +6,7 @@ end
 let get_object_stream (bucket_name : string) (object_path : string) :
     (string Lwt_stream.t, [> Error.t ]) Lwt_result.t =
   let open Lwt_result.Infix in
-  Auth.get_access_token ~scopes:[ Scopes.devstorage_read_only ] ()
-  |> Lwt_result.map_error (fun e -> `Gcloud_auth_error e)
+  Common.get_access_token ~scopes:[ Scopes.devstorage_read_only ] ()
   >>= fun token_info ->
   Lwt.catch
     (fun () ->
@@ -61,8 +60,7 @@ let list_objects ?(delimiter : string option) ?(prefix : string option)
     ?(page_token : string option) ~(bucket_name : string) () :
     (list_objects_response, [> Error.t ]) Lwt_result.t =
   let open Lwt_result.Infix in
-  Auth.get_access_token ~scopes:[ Scopes.devstorage_read_only ] ()
-  |> Lwt_result.map_error (fun e -> `Gcloud_auth_error e)
+  Common.get_access_token ~scopes:[ Scopes.devstorage_read_only ] ()
   >>= fun token_info ->
   Lwt.catch
     (fun () ->

--- a/test/container.ml
+++ b/test/container.ml
@@ -2,8 +2,9 @@ let tests : unit Alcotest_lwt.test_case list =
   [
     Alcotest_lwt.test_case "projects.locations.clusters.get" `Quick (fun _ () ->
         let open Lwt.Infix in
-        Gcloud.Container.Projects.Locations.Clusters.get ~project:"imandra-dev"
-          ~location:"europe-west1-c" ~cluster:"imandra-markets-dev-cluster"
+        Gcloud.Container.Projects.Locations.Clusters.get
+          ~project_id:"imandra-dev" ~location:"europe-west1-c"
+          ~cluster:"imandra-markets-dev-cluster" ()
         >>= function
         | Ok c ->
             Alcotest.(check string)


### PR DESCRIPTION
- prevent slow project-id lookups that arent needed
- simplify api slightly and split project_id lookup into a separate step