### PR TITLE
use name in dune-project

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,7 @@
 (lang dune 3.8)
 (using melange 0.1)
 
+(name gcloud)
 (source (github imandra-ai/ocaml-gcloud))
 (authors "Matt Bray <matt@imandra.ai>" "Dave Aitken <dave@imandra.ai>")
 (maintainers "Imandra <tech@imandra.ai>")


### PR DESCRIPTION
Adding name stanza in dune-project allows to `opam pin add gcloud https://github.com/yrk-pub/ocaml-gcloud.git` the repo. Currently this yields:
```
# File "dune-project", line 1, characters 0-0:
# Error: The project name is not defined, please add a (name <name>) field to
# your dune-project file.
```
