### PR TITLE
fix(cohttp): ensure response body is always consumed

### DIFF
--- a/src/container.ml
+++ b/src/container.ml
@@ -1,3 +1,5 @@
+let ok = Lwt_result.ok
+
 module Scopes = struct
   let cloud_platform = "https://www.googleapis.com/auth/cloud-platform"
 end
@@ -54,11 +56,12 @@ module Projects = struct
                       token_info.Auth.token.access_token );
                 ]
             in
-            Cohttp_lwt_unix.Client.get uri ~headers |> Lwt_result.ok)
+            let open Lwt.Infix in
+            Cohttp_lwt_unix.Client.get uri ~headers >>= Util.consume_body |> ok)
           (fun e -> Lwt_result.fail (`Network_error e))
         >>= fun (resp, body) ->
         match Cohttp.Response.status resp with
-        | `OK -> Error.parse_body_json of_yojson body
+        | `OK -> Error.parse_body_json of_yojson body |> Lwt.return
         | status_code -> Error.of_response_status_code_and_body status_code body
     end
   end

--- a/src/secretmanager.ml
+++ b/src/secretmanager.ml
@@ -1,3 +1,5 @@
+let ok = Lwt_result.ok
+
 module Scopes = struct
   let cloud_platform = "https://www.googleapis.com/auth/cloud-platform"
 end
@@ -43,12 +45,14 @@ module V1 = struct
                       );
                     ]
                 in
-                Cohttp_lwt_unix.Client.get uri ~headers |> Lwt_result.ok)
+                let open Lwt.Infix in
+                Cohttp_lwt_unix.Client.get uri ~headers
+                >>= Util.consume_body |> ok)
               (fun e -> Lwt_result.fail (`Network_error e))
           in
 
           match Cohttp.Response.status resp with
-          | `OK -> Error.parse_body_json response_of_yojson body
+          | `OK -> Error.parse_body_json response_of_yojson body |> Lwt.return
           | status_code ->
               Error.of_response_status_code_and_body status_code body
       end

--- a/src/stackdriver_errors.ml
+++ b/src/stackdriver_errors.ml
@@ -1,3 +1,5 @@
+let ok = Lwt_result.ok
+
 module Scopes = struct
   let stackdriver_integration =
     "https://www.googleapis.com/auth/stackdriver-integration"
@@ -80,7 +82,8 @@ let report ?project_id (report_request : report_request) :
         report_request |> report_request_to_yojson |> Yojson.Safe.to_string
       in
       let body = body_str |> Cohttp_lwt.Body.of_string in
-      Cohttp_lwt_unix.Client.post uri ~headers ~body |> Lwt_result.ok
+      (let open Lwt.Infix in
+      Cohttp_lwt_unix.Client.post uri ~headers ~body >>= Util.consume_body |> ok)
       >>= fun (response, body) ->
       let status = Cohttp.Response.status response in
       match status with

--- a/src/util.ml
+++ b/src/util.ml
@@ -8,3 +8,15 @@ module List = struct
     in
     aux [] xss
 end
+
+let consume_body ((resp, body) : Cohttp.Response.t * Cohttp_lwt.Body.t) :
+    (Cohttp.Response.t * string) Lwt.t =
+  let open Lwt.Syntax in
+  let* body_str = Cohttp_lwt.Body.to_string body in
+  Lwt.return (resp, body_str)
+
+let drain_body ((resp, body) : Cohttp.Response.t * Cohttp_lwt.Body.t) :
+    Cohttp.Response.t Lwt.t =
+  let open Lwt.Syntax in
+  let* () = Cohttp_lwt.Body.drain_body body in
+  Lwt.return resp


### PR DESCRIPTION
Try to make it obvious that the body is consumed using `Util.consume_body` or `Util.drain_body` right next to the request call site.