### PR TITLE
Dev cleanup

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,4 +35,4 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v26
-    - run: nix-shell -I nixpkgs=channel:nixos-23.05 --pure -p ocamlformat_0_22_4 dune_3 ocaml --run "dune build @fmt"
+    - run: nix-shell -I nixpkgs=channel:nixpkgs-unstable --pure -p ocamlformat_0_22_4 dune_3 ocaml --run "dune build @fmt"

--- a/flake.lock
+++ b/flake.lock
@@ -67,31 +67,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1709230475,
-        "narHash": "sha256-QI/0GiTvWxhBJ/bpredarfAUARnP6zE1vCOifsZ220A=",
+        "lastModified": 1729658218,
+        "narHash": "sha256-9Rg+AqLqvqqJniP/OQB3GtgXoAd8IlazsHp97va042Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b5f6e3881acf8ca8a35b8cdb8d4021e5bd469a4e",
+        "rev": "dfffb2e7a52d29a0ef8e21ec8a0f30487b227f1a",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
         "ref": "nixpkgs-unstable",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs2305": {
-      "locked": {
-        "lastModified": 1704290814,
-        "narHash": "sha256-LWvKHp7kGxk/GEtlrGYV68qIvPHkU9iToomNFGagixU=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "70bdadeb94ffc8806c0570eb5c2695ad29f0e421",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-23.05",
         "type": "indirect"
       }
     },
@@ -194,7 +179,6 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "nixpkgs2305": "nixpkgs2305",
         "opam-nix": "opam-nix",
         "opam-repository": "opam-repository"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,9 +2,6 @@
   inputs = {
     nixpkgs.url = "nixpkgs/nixpkgs-unstable";
 
-    #ocamlformat 0.22.4 is a bit old, so is only in older versions of nixpkgs
-    nixpkgs2305.url = "nixpkgs/nixos-23.05";
-
     flake-utils.url = "github:numtide/flake-utils";
     opam-nix = {
       url = "github:tweag/opam-nix";
@@ -16,12 +13,10 @@
     };
   };
 
-  outputs = { self, nixpkgs, nixpkgs2305, flake-utils, opam-nix, opam-repository
-    }@inputs:
+  outputs = { self, nixpkgs, flake-utils, opam-nix, opam-repository }@inputs:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        pkgs2305 = nixpkgs2305.legacyPackages.${system};
         fs = pkgs.lib.fileset;
         on = opam-nix.lib.${system};
         ocaml-version = "5.1.0";
@@ -106,9 +101,7 @@
           buildInputs = (map (p: opamScope.${p}) opamFilePackageNames) ++ [
             devOpamScope.utop
             devOpamScope.ocaml-lsp-server
-
-            #ocamlformat 0.22.4 is a bit old, so is only in older versions of nixpkgs
-            pkgs2305.ocamlformat_0_22_4
+            pkgs.ocamlformat_0_22_4
           ];
         };
       });

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,8 @@
 {
   inputs = {
     nixpkgs.url = "nixpkgs/nixpkgs-unstable";
-
     flake-utils.url = "github:numtide/flake-utils";
+
     opam-nix = {
       url = "github:tweag/opam-nix";
       inputs.opam-repository.follows = "opam-repository";
@@ -19,7 +19,7 @@
         pkgs = nixpkgs.legacyPackages.${system};
         fs = pkgs.lib.fileset;
         on = opam-nix.lib.${system};
-        ocaml-version = "5.1.0";
+        ocaml-version = "5.1.1";
         ocaml-base-compiler = ocaml-version;
 
         # List of opam files you which to be read by opam-nix
@@ -61,13 +61,6 @@
           fileset = fs.unions opamFiles;
         }) { inherit ocaml-base-compiler; });
 
-        # build any dev deps on the correct ocaml version, without conflicting with project deps.
-        devOpamScope = (on.queryToScope { repos = [ opam-repository ]; } {
-          inherit ocaml-base-compiler;
-          ocaml-lsp-server = "*";
-          utop = "*";
-        });
-
         gcloud-cli = pkgs.stdenv.mkDerivation {
           pname = "gcloud-cli";
           version = "1.0.0";
@@ -98,9 +91,10 @@
         packages.gcloud-cli = gcloud-cli;
 
         packages.default = pkgs.mkShell {
+          dontDetectOcamlConflicts = true;
           buildInputs = (map (p: opamScope.${p}) opamFilePackageNames) ++ [
-            devOpamScope.utop
-            devOpamScope.ocaml-lsp-server
+            pkgs.ocaml-ng.ocamlPackages_5_1.utop
+            pkgs.ocaml-ng.ocamlPackages_5_1.ocaml-lsp
             pkgs.ocamlformat_0_22_4
           ];
         };

--- a/flake.nix
+++ b/flake.nix
@@ -16,114 +16,100 @@
     };
   };
 
-  outputs = { self, nixpkgs, nixpkgs2305, flake-utils, opam-nix, opam-repository }@inputs:
-    flake-utils.lib.eachDefaultSystem
-      (system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-          pkgs2305 = nixpkgs2305.legacyPackages.${system};
-          fs = pkgs.lib.fileset;
-          on = opam-nix.lib.${system};
-          ocaml-version = "5.1.0";
-          ocaml-base-compiler = ocaml-version;
+  outputs = { self, nixpkgs, nixpkgs2305, flake-utils, opam-nix, opam-repository
+    }@inputs:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        pkgs2305 = nixpkgs2305.legacyPackages.${system};
+        fs = pkgs.lib.fileset;
+        on = opam-nix.lib.${system};
+        ocaml-version = "5.1.0";
+        ocaml-base-compiler = ocaml-version;
 
-          # List of opam files you which to be read by opam-nix
-          opamFiles = [
-            ./gcloud.opam
-            ./gcloud-cli.opam
+        # List of opam files you which to be read by opam-nix
+        opamFiles = [
+          ./gcloud.opam
+          ./gcloud-cli.opam
 
-            # Also include the opam files to any submoduled dependencies
-            # ./vendor/some-lib/some-lib.opam
+          # Also include the opam files to any submoduled dependencies
+          # ./vendor/some-lib/some-lib.opam
+        ];
+
+        opamFilePackageNames = (map (x:
+          (pkgs.lib.removeSuffix ".opam" (builtins.baseNameOf (toString x))))
+          opamFiles);
+
+        # attrset containing all opam packages defined in the opamFiles list
+        # for a specific OCaml version
+        opamScope = (on.buildOpamProject' {
+          repos = [ opam-repository ];
+          resolveArgs.with-test = true;
+          recursive = true;
+          overlays = on.__overlays ++ [
+            (final: prev:
+              builtins.foldl' (acc: pkg:
+                (acc // {
+                  # Allows us to treat the whole repo as a single unit and `dune build` it together,
+                  # without opam-nix attempting to build each opam package individually.
+                  # Similar to opam install --deps-only
+                  ${pkg} =
+                    prev.${pkg}.overrideAttrs (oa: { dontBuild = true; });
+                })) {
+                  # other-package-override = prev.other-package-overide.overrideAttrs (oa: {
+                  #   nativeBuildInputs = oa.nativeBuildInputs ++ (with pkgs; [ makeWrapper git ]);
+                  # });
+                } opamFilePackageNames)
           ];
+        } (fs.toSource {
+          root = ./.;
+          fileset = fs.unions opamFiles;
+        }) { inherit ocaml-base-compiler; });
 
-          opamFilePackageNames = (map
-            (x:
-              (pkgs.lib.removeSuffix ".opam" (builtins.baseNameOf (toString x))))
-            opamFiles);
-
-
-          # attrset containing all opam packages defined in the opamFiles list
-          # for a specific OCaml version
-          opamScope = (on.buildOpamProject'
-            {
-              repos = [ opam-repository ];
-              resolveArgs.with-test = true;
-              recursive = true;
-              overlays = on.__overlays ++ [
-                (final: prev:
-                  builtins.foldl'
-                    (acc: pkg:
-                      (acc // {
-                        # Allows us to treat the whole repo as a single unit and `dune build` it together,
-                        # without opam-nix attempting to build each opam package individually.
-                        # Similar to opam install --deps-only
-                        ${pkg} =
-                          prev.${pkg}.overrideAttrs (oa: { dontBuild = true; });
-                      }))
-                    {
-                      # other-package-override = prev.other-package-overide.overrideAttrs (oa: {
-                      #   nativeBuildInputs = oa.nativeBuildInputs ++ (with pkgs; [ makeWrapper git ]);
-                      # });
-                    }
-                    opamFilePackageNames)
-              ];
-            }
-            (fs.toSource {
-              root = ./.;
-              fileset = fs.unions opamFiles;
-            })
-            { inherit ocaml-base-compiler; });
-
-          # build any dev deps on the correct ocaml version, without conflicting with project deps.
-          devOpamScope = (on.queryToScope { repos = [ opam-repository ]; } {
-            inherit ocaml-base-compiler;
-            ocaml-lsp-server = "*";
-            utop = "*";
-          });
-
-          gcloud-cli = pkgs.stdenv.mkDerivation {
-            pname = "gcloud-cli";
-            version = "1.0.0";
-            buildInputs = (map (p: opamScope.${p}) opamFilePackageNames);
-            buildPhase = ''
-              dune build @install -p gcloud,gcloud-cli
-            '';
-
-            installPhase = ''
-              mkdir -p $out/bin
-              cp _build/install/default/bin/* $out/bin/
-            '';
-
-            src = (fs.toSource {
-              root = ./.;
-
-              # Prevent changes to the nix flake file from busting the build cache.
-              # Add any other files which the build should ignore to this list.
-              fileset = fs.difference ./. (fs.unions [
-                ./flake.nix
-                ./flake.lock
-              ]);
-            });
-          };
-
-        in
-
-
-        rec {
-          # for use by nix fmt
-          formatter = pkgs.nixpkgs-fmt;
-
-          packages.gcloud-cli = gcloud-cli;
-
-          packages.default = pkgs.mkShell {
-            buildInputs =
-              (map (p: opamScope.${p}) opamFilePackageNames) ++ [
-                devOpamScope.utop
-                devOpamScope.ocaml-lsp-server
-
-                #ocamlformat 0.22.4 is a bit old, so is only in older versions of nixpkgs
-                pkgs2305.ocamlformat_0_22_4
-              ];
-          };
+        # build any dev deps on the correct ocaml version, without conflicting with project deps.
+        devOpamScope = (on.queryToScope { repos = [ opam-repository ]; } {
+          inherit ocaml-base-compiler;
+          ocaml-lsp-server = "*";
+          utop = "*";
         });
+
+        gcloud-cli = pkgs.stdenv.mkDerivation {
+          pname = "gcloud-cli";
+          version = "1.0.0";
+          buildInputs = (map (p: opamScope.${p}) opamFilePackageNames);
+          buildPhase = ''
+            dune build @install -p gcloud,gcloud-cli
+          '';
+
+          installPhase = ''
+            mkdir -p $out/bin
+            cp _build/install/default/bin/* $out/bin/
+          '';
+
+          src = (fs.toSource {
+            root = ./.;
+
+            # Prevent changes to the nix flake file from busting the build cache.
+            # Add any other files which the build should ignore to this list.
+            fileset =
+              fs.difference ./. (fs.unions [ ./flake.nix ./flake.lock ]);
+          });
+        };
+
+      in rec {
+        # for use by nix fmt
+        formatter = pkgs.nixfmt-rfc-style;
+
+        packages.gcloud-cli = gcloud-cli;
+
+        packages.default = pkgs.mkShell {
+          buildInputs = (map (p: opamScope.${p}) opamFilePackageNames) ++ [
+            devOpamScope.utop
+            devOpamScope.ocaml-lsp-server
+
+            #ocamlformat 0.22.4 is a bit old, so is only in older versions of nixpkgs
+            pkgs2305.ocamlformat_0_22_4
+          ];
+        };
+      });
 }


### PR DESCRIPTION
- Remove extra copy of nixpkgs (ocamlformat_0_22_4 is back in main nixpkgs again)
- Get ocaml lsp / utop via nixpkgs rather than a separate dev opam scope