### PR TITLE
Cleanup dev setup

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,4 +35,4 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v26
-    - run: nix-shell -I nixpkgs=channel:nixos-23.05 --pure -p ocamlformat_0_22_4 dune_3 ocaml --run "dune build @fmt"
+    - run: nix-shell -I nixpkgs=channel:nixpkgs-unstable --pure -p ocamlformat_0_22_4 dune_3 ocaml --run "dune build @fmt"

--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,8 @@ opam-install-deps:
 
 format:
 	dune build @fmt --auto-promote
+
+onix-lock:
+	onix lock ./gcloud.opam ./gcloud-cli.opam --resolutions="ocaml-system=5.2.0" --lock-file ./onix-lock.json
+	onix lock ./gcloud.opam ./gcloud-cli.opam ./gcloud-melange.opam --resolutions="ocaml-system=5.2.0" --with-dev-setup=true --with-test=true --lock-file ./onix-lock-dev.json
+	git add onix-lock.json onix-lock-dev.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 OCaml bindings to the Google Cloud Platform APIs
 ================================================
+
+## Development
+
+The default nix devShell will have the packages needed to develop `ocaml-gcloud`:
+```
+nix develop '.#' # (or use nix-direnv)
+dune build ...
+```
+
+### Updating opam package set
+
+If you've updated the `.opam` files in the project and need to recalculate the `opam` deps, run `make onix-lock` and refresh the devShell:
+
+```
+# From inside the nix devShell
+$ make onix-lock
+$ exit # (or nix-direnv-reload if using nix-direnv)
+$ nix develop '.#'
+```

--- a/flake.lock
+++ b/flake.lock
@@ -67,31 +67,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1709230475,
-        "narHash": "sha256-QI/0GiTvWxhBJ/bpredarfAUARnP6zE1vCOifsZ220A=",
+        "lastModified": 1729658218,
+        "narHash": "sha256-9Rg+AqLqvqqJniP/OQB3GtgXoAd8IlazsHp97va042Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b5f6e3881acf8ca8a35b8cdb8d4021e5bd469a4e",
+        "rev": "dfffb2e7a52d29a0ef8e21ec8a0f30487b227f1a",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
         "ref": "nixpkgs-unstable",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs2305": {
-      "locked": {
-        "lastModified": 1704290814,
-        "narHash": "sha256-LWvKHp7kGxk/GEtlrGYV68qIvPHkU9iToomNFGagixU=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "70bdadeb94ffc8806c0570eb5c2695ad29f0e421",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-23.05",
         "type": "indirect"
       }
     },
@@ -194,7 +179,6 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "nixpkgs2305": "nixpkgs2305",
         "opam-nix": "opam-nix",
         "opam-repository": "opam-repository"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,21 +1,5 @@
 {
   "nodes": {
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1627913399,
-        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -36,42 +20,26 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "lastModified": 1652776076,
+        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "mirage-opam-overlays": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1661959605,
-        "narHash": "sha256-CPTuhYML3F4J58flfp3ZbMNhkRkVFKmBEYBZY5tnQwA=",
-        "owner": "dune-universe",
-        "repo": "mirage-opam-overlays",
-        "rev": "05f1c1823d891ce4d8adab91f5db3ac51d86dc0b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "dune-universe",
-        "repo": "mirage-opam-overlays",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729658218,
-        "narHash": "sha256-9Rg+AqLqvqqJniP/OQB3GtgXoAd8IlazsHp97va042Y=",
+        "lastModified": 1730170245,
+        "narHash": "sha256-PRq4vJjDa+m1mNwkV9H7zVzMhuMqsHJrTGx0iJZ0e0w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dfffb2e7a52d29a0ef8e21ec8a0f30487b227f1a",
+        "rev": "30c9efeef01e2ad4880bff6a01a61dd99536b3c9",
         "type": "github"
       },
       "original": {
@@ -80,98 +48,24 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1682362401,
-        "narHash": "sha256-/UMUHtF2CyYNl4b60Z2y4wwTTdIWGKhj9H301EDcT9M=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "884ac294018409e0d1adc0cae185439a44bd6b0b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "opam-nix": {
+    "onix": {
       "inputs": {
-        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils_2",
-        "mirage-opam-overlays": "mirage-opam-overlays",
-        "nixpkgs": "nixpkgs_2",
-        "opam-overlays": "opam-overlays",
-        "opam-repository": [
-          "opam-repository"
-        ],
-        "opam2json": "opam2json"
-      },
-      "locked": {
-        "lastModified": 1706878465,
-        "narHash": "sha256-0k0KSkU7epRQshZZKsOpyE79lnwn/0q2VagzDhIeZpE=",
-        "owner": "tweag",
-        "repo": "opam-nix",
-        "rev": "9f03f7e0664c369f25e614d3f3be74ea78b647fa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tweag",
-        "repo": "opam-nix",
-        "type": "github"
-      }
-    },
-    "opam-overlays": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1654162756,
-        "narHash": "sha256-RV68fUK+O3zTx61iiHIoS0LvIk0E4voMp+0SwRg6G6c=",
-        "owner": "dune-universe",
-        "repo": "opam-overlays",
-        "rev": "c8f6ef0fc5272f254df4a971a47de7848cc1c8a4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "dune-universe",
-        "repo": "opam-overlays",
-        "type": "github"
-      }
-    },
-    "opam-repository": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1709223424,
-        "narHash": "sha256-3b3VEugSQ195fz2dTQhXXj1ld3ujs6tyrdKt1ml72YQ=",
-        "owner": "ocaml",
-        "repo": "opam-repository",
-        "rev": "f17e271e4c6ab24012dcb143d923dc86435fa51c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ocaml",
-        "repo": "opam-repository",
-        "type": "github"
-      }
-    },
-    "opam2json": {
-      "inputs": {
         "nixpkgs": [
-          "opam-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1671540003,
-        "narHash": "sha256-5pXfbUfpVABtKbii6aaI2EdAZTjHJ2QntEf0QD2O5AM=",
-        "owner": "tweag",
-        "repo": "opam2json",
-        "rev": "819d291ea95e271b0e6027679de6abb4d4f7f680",
+        "lastModified": 1726775591,
+        "narHash": "sha256-AnNG7PrYN5Svhttfa1Cb31cNkHD+4ExgEGe/GPAecYs=",
+        "owner": "rizo",
+        "repo": "onix",
+        "rev": "3740a2beb84bc21860385f8bbb0d5f557842de03",
         "type": "github"
       },
       "original": {
-        "owner": "tweag",
-        "repo": "opam2json",
+        "owner": "rizo",
+        "repo": "onix",
         "type": "github"
       }
     },
@@ -179,8 +73,7 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "opam-nix": "opam-nix",
-        "opam-repository": "opam-repository"
+        "onix": "onix"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,9 +2,6 @@
   inputs = {
     nixpkgs.url = "nixpkgs/nixpkgs-unstable";
 
-    #ocamlformat 0.22.4 is a bit old, so is only in older versions of nixpkgs
-    nixpkgs2305.url = "nixpkgs/nixos-23.05";
-
     flake-utils.url = "github:numtide/flake-utils";
     opam-nix = {
       url = "github:tweag/opam-nix";
@@ -16,12 +13,10 @@
     };
   };
 
-  outputs = { self, nixpkgs, nixpkgs2305, flake-utils, opam-nix, opam-repository
-    }@inputs:
+  outputs = { self, nixpkgs, flake-utils, opam-nix, opam-repository }@inputs:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        pkgs2305 = nixpkgs2305.legacyPackages.${system};
         fs = pkgs.lib.fileset;
         on = opam-nix.lib.${system};
         ocaml-version = "5.1.0";
@@ -106,9 +101,7 @@
           buildInputs = (map (p: opamScope.${p}) opamFilePackageNames) ++ [
             devOpamScope.utop
             devOpamScope.ocaml-lsp-server
-
-            #ocamlformat 0.22.4 is a bit old, so is only in older versions of nixpkgs
-            pkgs2305.ocamlformat_0_22_4
+            pkgs.ocamlformat_0_22_4
           ];
         };
       });

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,8 @@
 {
   inputs = {
     nixpkgs.url = "nixpkgs/nixpkgs-unstable";
-
     flake-utils.url = "github:numtide/flake-utils";
+
     opam-nix = {
       url = "github:tweag/opam-nix";
       inputs.opam-repository.follows = "opam-repository";
@@ -19,7 +19,7 @@
         pkgs = nixpkgs.legacyPackages.${system};
         fs = pkgs.lib.fileset;
         on = opam-nix.lib.${system};
-        ocaml-version = "5.1.0";
+        ocaml-version = "5.1.1";
         ocaml-base-compiler = ocaml-version;
 
         # List of opam files you which to be read by opam-nix
@@ -61,13 +61,6 @@
           fileset = fs.unions opamFiles;
         }) { inherit ocaml-base-compiler; });
 
-        # build any dev deps on the correct ocaml version, without conflicting with project deps.
-        devOpamScope = (on.queryToScope { repos = [ opam-repository ]; } {
-          inherit ocaml-base-compiler;
-          ocaml-lsp-server = "*";
-          utop = "*";
-        });
-
         gcloud-cli = pkgs.stdenv.mkDerivation {
           pname = "gcloud-cli";
           version = "1.0.0";
@@ -98,9 +91,10 @@
         packages.gcloud-cli = gcloud-cli;
 
         packages.default = pkgs.mkShell {
+          dontDetectOcamlConflicts = true;
           buildInputs = (map (p: opamScope.${p}) opamFilePackageNames) ++ [
-            devOpamScope.utop
-            devOpamScope.ocaml-lsp-server
+            pkgs.ocaml-ng.ocamlPackages_5_1.utop
+            pkgs.ocaml-ng.ocamlPackages_5_1.ocaml-lsp
             pkgs.ocamlformat_0_22_4
           ];
         };

--- a/flake.nix
+++ b/flake.nix
@@ -3,100 +3,38 @@
     nixpkgs.url = "nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
 
-    opam-nix = {
-      url = "github:tweag/opam-nix";
-      inputs.opam-repository.follows = "opam-repository";
-    };
-    opam-repository = {
-      url = "github:ocaml/opam-repository";
-      flake = false;
-    };
+    onix.url = "github:rizo/onix";
+    onix.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, flake-utils, opam-nix, opam-repository }@inputs:
+  outputs = { self, nixpkgs, flake-utils, onix }@inputs:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        fs = pkgs.lib.fileset;
-        on = opam-nix.lib.${system};
-        ocaml-version = "5.1.1";
-        ocaml-base-compiler = ocaml-version;
-
-        # List of opam files you which to be read by opam-nix
-        opamFiles = [
-          ./gcloud.opam
-          ./gcloud-cli.opam
-
-          # Also include the opam files to any submoduled dependencies
-          # ./vendor/some-lib/some-lib.opam
-        ];
-
-        opamFilePackageNames = (map (x:
-          (pkgs.lib.removeSuffix ".opam" (builtins.baseNameOf (toString x))))
-          opamFiles);
-
-        # attrset containing all opam packages defined in the opamFiles list
-        # for a specific OCaml version
-        opamScope = (on.buildOpamProject' {
-          repos = [ opam-repository ];
-          resolveArgs.with-test = true;
-          recursive = true;
-          overlays = on.__overlays ++ [
-            (final: prev:
-              builtins.foldl' (acc: pkg:
-                (acc // {
-                  # Allows us to treat the whole repo as a single unit and `dune build` it together,
-                  # without opam-nix attempting to build each opam package individually.
-                  # Similar to opam install --deps-only
-                  ${pkg} =
-                    prev.${pkg}.overrideAttrs (oa: { dontBuild = true; });
-                })) {
-                  # other-package-override = prev.other-package-overide.overrideAttrs (oa: {
-                  #   nativeBuildInputs = oa.nativeBuildInputs ++ (with pkgs; [ makeWrapper git ]);
-                  # });
-                } opamFilePackageNames)
-          ];
-        } (fs.toSource {
-          root = ./.;
-          fileset = fs.unions opamFiles;
-        }) { inherit ocaml-base-compiler; });
-
-        gcloud-cli = pkgs.stdenv.mkDerivation {
-          pname = "gcloud-cli";
-          version = "1.0.0";
-          buildInputs = (map (p: opamScope.${p}) opamFilePackageNames);
-          buildPhase = ''
-            dune build @install -p gcloud,gcloud-cli
-          '';
-
-          installPhase = ''
-            mkdir -p $out/bin
-            cp _build/install/default/bin/* $out/bin/
-          '';
-
-          src = (fs.toSource {
-            root = ./.;
-
-            # Prevent changes to the nix flake file from busting the build cache.
-            # Add any other files which the build should ignore to this list.
-            fileset =
-              fs.difference ./. (fs.unions [ ./flake.nix ./flake.lock ]);
-          });
+        onix' = onix.packages.${system}.latest;
+        onixEnv = onix'.env {
+          path = ./.;
+          # roots = [./gcloud.opam ./gcloud-cli.opam];
+          lock = ./onix-lock.json;
+        };
+        onixEnvDev = onix'.env {
+          path = ./.;
+          # roots = [./gcloud.opam ./gcloud-cli.opam];
+          lock = ./onix-lock-dev.json;
         };
 
       in rec {
         # for use by nix fmt
         formatter = pkgs.nixfmt-rfc-style;
 
-        packages.gcloud-cli = gcloud-cli;
+        packages.gcloud-cli = onixEnv.pkgs.gcloud-cli;
 
-        packages.default = pkgs.mkShell {
-          dontDetectOcamlConflicts = true;
-          buildInputs = (map (p: opamScope.${p}) opamFilePackageNames) ++ [
-            pkgs.ocaml-ng.ocamlPackages_5_1.utop
-            pkgs.ocaml-ng.ocamlPackages_5_1.ocaml-lsp
-            pkgs.ocamlformat_0_22_4
-          ];
-        };
+        devShells.onixLock = pkgs.mkShell { buildInputs = [ onix' ]; };
+
+        devShells.default = onixEnvDev.shell.overrideAttrs (final: prev: {
+          buildInputs = prev.buildInputs ++ [ pkgs.ocamlformat_0_22_4 onix' ];
+        });
+
+        packages.dev-shell = devShells.default.inputDerivation;
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -16,114 +16,100 @@
     };
   };
 
-  outputs = { self, nixpkgs, nixpkgs2305, flake-utils, opam-nix, opam-repository }@inputs:
-    flake-utils.lib.eachDefaultSystem
-      (system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-          pkgs2305 = nixpkgs2305.legacyPackages.${system};
-          fs = pkgs.lib.fileset;
-          on = opam-nix.lib.${system};
-          ocaml-version = "5.1.0";
-          ocaml-base-compiler = ocaml-version;
+  outputs = { self, nixpkgs, nixpkgs2305, flake-utils, opam-nix, opam-repository
+    }@inputs:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        pkgs2305 = nixpkgs2305.legacyPackages.${system};
+        fs = pkgs.lib.fileset;
+        on = opam-nix.lib.${system};
+        ocaml-version = "5.1.0";
+        ocaml-base-compiler = ocaml-version;
 
-          # List of opam files you which to be read by opam-nix
-          opamFiles = [
-            ./gcloud.opam
-            ./gcloud-cli.opam
+        # List of opam files you which to be read by opam-nix
+        opamFiles = [
+          ./gcloud.opam
+          ./gcloud-cli.opam
 
-            # Also include the opam files to any submoduled dependencies
-            # ./vendor/some-lib/some-lib.opam
+          # Also include the opam files to any submoduled dependencies
+          # ./vendor/some-lib/some-lib.opam
+        ];
+
+        opamFilePackageNames = (map (x:
+          (pkgs.lib.removeSuffix ".opam" (builtins.baseNameOf (toString x))))
+          opamFiles);
+
+        # attrset containing all opam packages defined in the opamFiles list
+        # for a specific OCaml version
+        opamScope = (on.buildOpamProject' {
+          repos = [ opam-repository ];
+          resolveArgs.with-test = true;
+          recursive = true;
+          overlays = on.__overlays ++ [
+            (final: prev:
+              builtins.foldl' (acc: pkg:
+                (acc // {
+                  # Allows us to treat the whole repo as a single unit and `dune build` it together,
+                  # without opam-nix attempting to build each opam package individually.
+                  # Similar to opam install --deps-only
+                  ${pkg} =
+                    prev.${pkg}.overrideAttrs (oa: { dontBuild = true; });
+                })) {
+                  # other-package-override = prev.other-package-overide.overrideAttrs (oa: {
+                  #   nativeBuildInputs = oa.nativeBuildInputs ++ (with pkgs; [ makeWrapper git ]);
+                  # });
+                } opamFilePackageNames)
           ];
+        } (fs.toSource {
+          root = ./.;
+          fileset = fs.unions opamFiles;
+        }) { inherit ocaml-base-compiler; });
 
-          opamFilePackageNames = (map
-            (x:
-              (pkgs.lib.removeSuffix ".opam" (builtins.baseNameOf (toString x))))
-            opamFiles);
-
-
-          # attrset containing all opam packages defined in the opamFiles list
-          # for a specific OCaml version
-          opamScope = (on.buildOpamProject'
-            {
-              repos = [ opam-repository ];
-              resolveArgs.with-test = true;
-              recursive = true;
-              overlays = on.__overlays ++ [
-                (final: prev:
-                  builtins.foldl'
-                    (acc: pkg:
-                      (acc // {
-                        # Allows us to treat the whole repo as a single unit and `dune build` it together,
-                        # without opam-nix attempting to build each opam package individually.
-                        # Similar to opam install --deps-only
-                        ${pkg} =
-                          prev.${pkg}.overrideAttrs (oa: { dontBuild = true; });
-                      }))
-                    {
-                      # other-package-override = prev.other-package-overide.overrideAttrs (oa: {
-                      #   nativeBuildInputs = oa.nativeBuildInputs ++ (with pkgs; [ makeWrapper git ]);
-                      # });
-                    }
-                    opamFilePackageNames)
-              ];
-            }
-            (fs.toSource {
-              root = ./.;
-              fileset = fs.unions opamFiles;
-            })
-            { inherit ocaml-base-compiler; });
-
-          # build any dev deps on the correct ocaml version, without conflicting with project deps.
-          devOpamScope = (on.queryToScope { repos = [ opam-repository ]; } {
-            inherit ocaml-base-compiler;
-            ocaml-lsp-server = "*";
-            utop = "*";
-          });
-
-          gcloud-cli = pkgs.stdenv.mkDerivation {
-            pname = "gcloud-cli";
-            version = "1.0.0";
-            buildInputs = (map (p: opamScope.${p}) opamFilePackageNames);
-            buildPhase = ''
-              dune build @install -p gcloud,gcloud-cli
-            '';
-
-            installPhase = ''
-              mkdir -p $out/bin
-              cp _build/install/default/bin/* $out/bin/
-            '';
-
-            src = (fs.toSource {
-              root = ./.;
-
-              # Prevent changes to the nix flake file from busting the build cache.
-              # Add any other files which the build should ignore to this list.
-              fileset = fs.difference ./. (fs.unions [
-                ./flake.nix
-                ./flake.lock
-              ]);
-            });
-          };
-
-        in
-
-
-        rec {
-          # for use by nix fmt
-          formatter = pkgs.nixpkgs-fmt;
-
-          packages.gcloud-cli = gcloud-cli;
-
-          packages.default = pkgs.mkShell {
-            buildInputs =
-              (map (p: opamScope.${p}) opamFilePackageNames) ++ [
-                devOpamScope.utop
-                devOpamScope.ocaml-lsp-server
-
-                #ocamlformat 0.22.4 is a bit old, so is only in older versions of nixpkgs
-                pkgs2305.ocamlformat_0_22_4
-              ];
-          };
+        # build any dev deps on the correct ocaml version, without conflicting with project deps.
+        devOpamScope = (on.queryToScope { repos = [ opam-repository ]; } {
+          inherit ocaml-base-compiler;
+          ocaml-lsp-server = "*";
+          utop = "*";
         });
+
+        gcloud-cli = pkgs.stdenv.mkDerivation {
+          pname = "gcloud-cli";
+          version = "1.0.0";
+          buildInputs = (map (p: opamScope.${p}) opamFilePackageNames);
+          buildPhase = ''
+            dune build @install -p gcloud,gcloud-cli
+          '';
+
+          installPhase = ''
+            mkdir -p $out/bin
+            cp _build/install/default/bin/* $out/bin/
+          '';
+
+          src = (fs.toSource {
+            root = ./.;
+
+            # Prevent changes to the nix flake file from busting the build cache.
+            # Add any other files which the build should ignore to this list.
+            fileset =
+              fs.difference ./. (fs.unions [ ./flake.nix ./flake.lock ]);
+          });
+        };
+
+      in rec {
+        # for use by nix fmt
+        formatter = pkgs.nixfmt-rfc-style;
+
+        packages.gcloud-cli = gcloud-cli;
+
+        packages.default = pkgs.mkShell {
+          buildInputs = (map (p: opamScope.${p}) opamFilePackageNames) ++ [
+            devOpamScope.utop
+            devOpamScope.ocaml-lsp-server
+
+            #ocamlformat 0.22.4 is a bit old, so is only in older versions of nixpkgs
+            pkgs2305.ocamlformat_0_22_4
+          ];
+        };
+      });
 }

--- a/onix-lock-dev.json
+++ b/onix-lock-dev.json
@@ -1,0 +1,2137 @@
+{
+   "version": "0.0.5",
+   "repositories": [
+     {
+       "url": "https://github.com/ocaml/opam-repository.git",
+       "rev": "ce4637ae20e511e8dc54562b123f1407fa5b2ca8"
+     }
+   ],
+   "packages" : {
+     "alcotest": {
+       "version": "1.8.0",
+       "src": {
+         "url": "https://github.com/mirage/alcotest/releases/download/1.8.0/alcotest-1.8.0.tbz",
+         "sha256": "cba1bd01707c8c55b4764bb0df8c9c732be321e1f1c1a96a406e56d8dbca1d0e"
+       },
+       "depends": [
+         "astring",
+         "cmdliner",
+         "dune",
+         "fmt",
+         "ocaml",
+         "ocaml-syntax-shims",
+         "re",
+         "stdlib-shims",
+         "uutf"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "alcotest-lwt": {
+       "version": "1.8.0",
+       "src": {
+         "url": "https://github.com/mirage/alcotest/releases/download/1.8.0/alcotest-1.8.0.tbz",
+         "sha256": "cba1bd01707c8c55b4764bb0df8c9c732be321e1f1c1a96a406e56d8dbca1d0e"
+       },
+       "depends": [
+         "alcotest",
+         "dune",
+         "fmt",
+         "logs",
+         "lwt",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "angstrom": {
+       "version": "0.16.1",
+       "src": {
+         "url": "https://github.com/inhabitedtype/angstrom/archive/0.16.1.tar.gz",
+         "sha256": "143536fb4d049574c539b9990840615e078ed3dd94e1d24888293f68349a100b"
+       },
+       "depends": [
+         "bigstringaf",
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune",
+         "ocaml-syntax-shims"
+       ]
+     },
+     "asn1-combinators": {
+       "version": "0.2.6",
+       "src": {
+         "url": "https://github.com/mirleft/ocaml-asn1-combinators/releases/download/v0.2.6/asn1-combinators-v0.2.6.tbz",
+         "sha256": "012ade0d8869ef621063752c1cf8ea026f6bc702fed10df9af56688e291b1a91"
+       },
+       "depends": [
+         "cstruct",
+         "dune",
+         "ocaml",
+         "ptime",
+         "zarith"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "astring": {
+       "version": "0.8.5",
+       "src": {
+         "url": "https://erratique.ch/software/astring/releases/astring-0.8.5.tbz",
+         "sha256": "865692630c07c3ab87c66cdfc2734c0fdfc9c34a57f8e89ffec7c7d15e7a70fa"
+       },
+       "depends": [
+         "ocaml"
+       ],
+       "build-depends": [
+         "ocamlbuild",
+         "ocamlfind",
+         "topkg"
+       ]
+     },
+     "base": {
+       "version": "v0.17.1",
+       "src": {
+         "url": "https://github.com/janestreet/base/archive/refs/tags/v0.17.1.tar.gz",
+         "sha512": "ed5eb5e83d8085fc06f111862d609b393e394bbdcc6e25bab50030a250ffa2e540dbee02169b6f28ec220f10f61d189cd7b5646eece910c63620f5174fb5a655"
+       },
+       "depends": [
+         "dune",
+         "dune-configurator",
+         "ocaml",
+         "ocaml_intrinsics_kernel",
+         "sexplib0"
+       ],
+       "build-depends": [
+         "dune",
+         "dune-configurator"
+       ]
+     },
+     "base-bigarray": {
+       "version": "base"
+     },
+     "base-bytes": {
+       "version": "base",
+       "depends": [
+         "ocaml",
+         "ocamlfind"
+       ],
+       "build-depends": [
+         "ocamlfind"
+       ]
+     },
+     "base-domains": {
+       "version": "base",
+       "depends": [
+         "ocaml"
+       ]
+     },
+     "base-nnp": {
+       "version": "base",
+       "depends": [
+         "base-domains"
+       ]
+     },
+     "base-threads": {
+       "version": "base"
+     },
+     "base-unix": {
+       "version": "base"
+     },
+     "base64": {
+       "version": "3.5.1",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-base64/releases/download/v3.5.1/base64-3.5.1.tbz",
+         "sha256": "d8fedaa59bd12feae7acc08b5928dd478aac523f4ca8d240470d2500651c65ed"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "bigstringaf": {
+       "version": "0.10.0",
+       "src": {
+         "url": "https://github.com/inhabitedtype/bigstringaf/archive/0.10.0.tar.gz",
+         "sha256": "0a4zfb1plzvcq42rfkxfm4bkg3q6n5clswzczkgbj4dwbyqgb4pd"
+       },
+       "depends": [
+         "dune",
+         "dune-configurator",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune",
+         "dune-configurator"
+       ]
+     },
+     "bos": {
+       "version": "0.2.1",
+       "src": {
+         "url": "https://erratique.ch/software/bos/releases/bos-0.2.1.tbz",
+         "sha512": "8daeb8a4c2dd1f2460f6274ada19f4f1b6ebe875ff83a938c93418ce0e6bdb74b8afc5c9a7d410c1c9df2dad030e4fa276b6ed2da580639484e8b5bc92610b1d"
+       },
+       "depends": [
+         "astring",
+         "base-unix",
+         "fmt",
+         "fpath",
+         "logs",
+         "ocaml",
+         "rresult"
+       ],
+       "build-depends": [
+         "ocamlbuild",
+         "ocamlfind",
+         "topkg"
+       ]
+     },
+     "ca-certs": {
+       "version": "0.2.3",
+       "src": {
+         "url": "https://github.com/mirage/ca-certs/releases/download/v0.2.3/ca-certs-0.2.3.tbz",
+         "sha256": "d2d8d6457d915ef6d783def82f3be5ec2f56f92e20214f58edd63c9c2fc60e9c"
+       },
+       "depends": [
+         "astring",
+         "bos",
+         "dune",
+         "fpath",
+         "logs",
+         "mirage-crypto",
+         "ocaml",
+         "ptime",
+         "x509"
+       ],
+       "build-depends": [
+         "dune"
+       ],
+       "depexts": [
+         "ca_root_nss"
+       ]
+     },
+     "camlp-streams": {
+       "version": "5.0.1",
+       "src": {
+         "url": "https://github.com/ocaml/camlp-streams/archive/v5.0.1.tar.gz",
+         "sha512": "2efa8dd4a636217c8d49bac1e4e7e5558fc2f45cfea66514140a59fd99dd08d61fb9f1e17804997ff648b71b13820a5d4a1eb70fed9d848aa2abd6e41f853c86"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "camlzip": {
+       "version": "1.13",
+       "src": {
+         "url": "https://github.com/xavierleroy/camlzip/archive/rel113.tar.gz",
+         "sha256": "8a038692ac811cdd2fdff9b37b5892b7a912c2042641187eae29757d98565d9e"
+       },
+       "depends": [
+         "conf-zlib",
+         "ocaml"
+       ],
+       "build-depends": [
+         "ocamlfind"
+       ]
+     },
+     "chrome-trace": {
+       "version": "3.16.0",
+       "src": {
+         "url": "https://github.com/ocaml/dune/releases/download/3.16.0/dune-3.16.0.tbz",
+         "sha256": "5481dde7918ca3121e02c34d74339f734b32d5883efb8c1b8056471e74f9bda6"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "cmdliner": {
+       "version": "1.3.0",
+       "src": {
+         "url": "https://erratique.ch/software/cmdliner/releases/cmdliner-1.3.0.tbz",
+         "sha512": "4c46bc334444ff772637deae2f5ba03645d7a1b7db523470a1246acfce79b971c764d964cbb02388639b3161b279700d9ade95da550446fb32aa4849c8a8f283"
+       },
+       "depends": [
+         "ocaml"
+       ]
+     },
+     "cohttp": {
+       "version": "5.3.1",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-cohttp/releases/download/v5.3.1/cohttp-5.3.1.tbz",
+         "sha256": "f5e273d3c2f29ff47bd7e16db23e1f3d6cd01a40be00208985bc434c88d4576b"
+       },
+       "depends": [
+         "base-bytes",
+         "base64",
+         "dune",
+         "ocaml",
+         "ppx_sexp_conv",
+         "re",
+         "sexplib0",
+         "stringext",
+         "uri",
+         "uri-sexp"
+       ],
+       "build-depends": [
+         "dune",
+         "jsonm"
+       ]
+     },
+     "cohttp-lwt": {
+       "version": "5.3.0",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-cohttp/releases/download/v5.3.0/cohttp-5.3.0.tbz",
+         "sha256": "b3bd91c704e5ea510e924b83ab2ede1fc46a2cce448b0f8cef4883b9a16eeddd"
+       },
+       "depends": [
+         "cohttp",
+         "dune",
+         "logs",
+         "lwt",
+         "ocaml",
+         "ppx_sexp_conv",
+         "sexplib0",
+         "uri"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "cohttp-lwt-unix": {
+       "version": "5.3.0",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-cohttp/releases/download/v5.3.0/cohttp-5.3.0.tbz",
+         "sha256": "b3bd91c704e5ea510e924b83ab2ede1fc46a2cce448b0f8cef4883b9a16eeddd"
+       },
+       "depends": [
+         "base-unix",
+         "cmdliner",
+         "cohttp-lwt",
+         "conduit-lwt",
+         "conduit-lwt-unix",
+         "dune",
+         "fmt",
+         "logs",
+         "lwt",
+         "magic-mime",
+         "ocaml",
+         "ppx_sexp_conv"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "conduit": {
+       "version": "6.2.3",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-conduit/releases/download/v6.2.3/conduit-6.2.3.tbz",
+         "sha256": "3a4684bb1485b1f247d6084dd0a356e1027e92c2cd467b35cabd59a764423e79"
+       },
+       "depends": [
+         "astring",
+         "dune",
+         "ipaddr",
+         "ipaddr-sexp",
+         "logs",
+         "ocaml",
+         "ppx_sexp_conv",
+         "sexplib",
+         "uri"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "conduit-lwt": {
+       "version": "6.2.3",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-conduit/releases/download/v6.2.3/conduit-6.2.3.tbz",
+         "sha256": "3a4684bb1485b1f247d6084dd0a356e1027e92c2cd467b35cabd59a764423e79"
+       },
+       "depends": [
+         "base-unix",
+         "conduit",
+         "dune",
+         "lwt",
+         "ocaml",
+         "ppx_sexp_conv",
+         "sexplib"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "conduit-lwt-unix": {
+       "version": "6.2.3",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-conduit/releases/download/v6.2.3/conduit-6.2.3.tbz",
+         "sha256": "3a4684bb1485b1f247d6084dd0a356e1027e92c2cd467b35cabd59a764423e79"
+       },
+       "depends": [
+         "base-unix",
+         "ca-certs",
+         "conduit-lwt",
+         "dune",
+         "ipaddr",
+         "ipaddr-sexp",
+         "logs",
+         "lwt",
+         "ocaml",
+         "ppx_sexp_conv",
+         "tls-lwt",
+         "uri"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "conf-gmp": {
+       "version": "4",
+       "src-extra": {
+         "test.c": {
+           "url": "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/conf-gmp/test.c.4",
+           "sha256": "54a30735f1f271a2531526747e75716f4490dd7bc1546efd6498ccfe3cc4d6fb"
+         }
+       },
+       "depexts": [
+         "gmp"
+       ]
+     },
+     "conf-gmp-powm-sec": {
+       "version": "3",
+       "src-extra": {
+         "test.c": {
+           "url": "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/conf-gmp-powm-sec/test.c.3",
+           "sha256": "388b3879530257a7e6e59b68208ee2a52de7be30e40eb4d3a54419708fdad490"
+         }
+       },
+       "depends": [
+         "conf-gmp"
+       ]
+     },
+     "conf-pkg-config": {
+       "version": "3",
+       "depexts": [
+         "pkg-config"
+       ]
+     },
+     "conf-zlib": {
+       "version": "1",
+       "build-depends": [
+         "conf-pkg-config"
+       ],
+       "depexts": [
+         "zlib"
+       ]
+     },
+     "containers": {
+       "version": "3.14",
+       "src": {
+         "url": "https://github.com/c-cube/ocaml-containers/releases/download/v3.14/containers-3.14.tbz",
+         "sha256": "c94fba0c7c54349b7021c31f85120495197ddde438c574d48362ec669bf7e564"
+       },
+       "depends": [
+         "base-threads",
+         "base-unix",
+         "dune",
+         "dune-configurator",
+         "either",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune",
+         "dune-configurator"
+       ]
+     },
+     "cppo": {
+       "version": "1.7.0",
+       "src": {
+         "url": "https://github.com/ocaml-community/cppo/archive/refs/tags/v1.7.0.tar.gz",
+         "sha512": "cafa2f7add42912b413f39e1d9fb7a2a42a9be134128c179dfe353f35a6c32840720d2166a77d985941300cb945b9c424b38401d20027d814b25f3bac534506d"
+       },
+       "depends": [
+         "base-unix",
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "csexp": {
+       "version": "1.5.2",
+       "src": {
+         "url": "https://github.com/ocaml-dune/csexp/releases/download/1.5.2/csexp-1.5.2.tbz",
+         "sha256": "1a14dd04bb4379a41990248550628c77913a9c07f3c35c1370b6960e697787ff"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "cstruct": {
+       "version": "6.2.0",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-cstruct/releases/download/v6.2.0/cstruct-6.2.0.tbz",
+         "sha256": "9a78073392580e8349148fa3ab4b1b2e989dc9d30d07401b04c96b7c60f03e62"
+       },
+       "depends": [
+         "dune",
+         "fmt",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "domain-name": {
+       "version": "0.4.0",
+       "src": {
+         "url": "https://github.com/hannesm/domain-name/releases/download/v0.4.0/domain-name-0.4.0.tbz",
+         "sha256": "a5c06e22845895201973e812fe3019274d1db81c0a7873da6c8007c4ad2108c5"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "dune": {
+       "version": "3.16.0",
+       "src": {
+         "url": "https://github.com/ocaml/dune/releases/download/3.16.0/dune-3.16.0.tbz",
+         "sha256": "5481dde7918ca3121e02c34d74339f734b32d5883efb8c1b8056471e74f9bda6"
+       },
+       "depends": [
+         "base-threads",
+         "base-unix",
+         "ocaml"
+       ]
+     },
+     "dune-build-info": {
+       "version": "3.16.0",
+       "src": {
+         "url": "https://github.com/ocaml/dune/releases/download/3.16.0/dune-3.16.0.tbz",
+         "sha256": "5481dde7918ca3121e02c34d74339f734b32d5883efb8c1b8056471e74f9bda6"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "dune-configurator": {
+       "version": "3.16.0",
+       "src": {
+         "url": "https://github.com/ocaml/dune/releases/download/3.16.0/dune-3.16.0.tbz",
+         "sha256": "5481dde7918ca3121e02c34d74339f734b32d5883efb8c1b8056471e74f9bda6"
+       },
+       "depends": [
+         "base-unix",
+         "csexp",
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "dune-rpc": {
+       "version": "3.16.0",
+       "src": {
+         "url": "https://github.com/ocaml/dune/releases/download/3.16.0/dune-3.16.0.tbz",
+         "sha256": "5481dde7918ca3121e02c34d74339f734b32d5883efb8c1b8056471e74f9bda6"
+       },
+       "depends": [
+         "csexp",
+         "dune",
+         "dyn",
+         "ordering",
+         "pp",
+         "stdune",
+         "xdg"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "duration": {
+       "version": "0.2.1",
+       "src": {
+         "url": "https://github.com/hannesm/duration/releases/download/v0.2.1/duration-0.2.1.tbz",
+         "sha256": "c738c1f38cfb99820c121cd3ddf819de4b2228f0d50eacbd1cc3ce99e7c71e2b"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "dyn": {
+       "version": "3.16.0",
+       "src": {
+         "url": "https://github.com/ocaml/dune/releases/download/3.16.0/dune-3.16.0.tbz",
+         "sha256": "5481dde7918ca3121e02c34d74339f734b32d5883efb8c1b8056471e74f9bda6"
+       },
+       "depends": [
+         "dune",
+         "ocaml",
+         "ordering",
+         "pp"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "either": {
+       "version": "1.0.0",
+       "src": {
+         "url": "https://github.com/mirage/either/releases/download/1.0.0/either-1.0.0.tbz",
+         "sha256": "bf674de3312dee7b7215f07df1e8a96eb3d679164b8a918cdd95b8d97e505884"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "eqaf": {
+       "version": "0.9",
+       "src": {
+         "url": "https://github.com/mirage/eqaf/releases/download/v0.9/eqaf-0.9.tbz",
+         "sha256": "ec0e28a946ac6817f95d5854f05a9961ae3a8408bb610e79cfad01b9b255dfe0"
+       },
+       "depends": [
+         "cstruct",
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ezgzip": {
+       "version": "0.2.3",
+       "src": {
+         "url": "https://github.com/hcarty/ezgzip/releases/download/v0.2.3/ezgzip-v0.2.3.tbz",
+         "sha256": "8868eedb98f83b2d53f091a827db9b7a5b4e9ba538bbc080c91b4ac4baf679d4"
+       },
+       "depends": [
+         "astring",
+         "camlzip",
+         "dune",
+         "ocaml",
+         "ocplib-endian",
+         "rresult"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "fiber": {
+       "version": "3.7.0",
+       "src": {
+         "url": "https://github.com/ocaml-dune/fiber/releases/download/3.7.0/fiber-lwt-3.7.0.tbz",
+         "sha256": "8648a15ae93fe6942999ce36887429a3913b62829c4714e520cc0e7a1c3b9682"
+       },
+       "depends": [
+         "dune",
+         "dyn",
+         "ocaml",
+         "stdune"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "fmt": {
+       "version": "0.9.0",
+       "src": {
+         "url": "https://erratique.ch/software/fmt/releases/fmt-0.9.0.tbz",
+         "sha512": "66cf4b8bb92232a091dfda5e94d1c178486a358cdc34b1eec516d48ea5acb6209c0dfcb416f0c516c50ddbddb3c94549a45e4a6d5c5fd1c81d3374dec823a83b"
+       },
+       "depends": [
+         "base-unix",
+         "cmdliner",
+         "ocaml"
+       ],
+       "build-depends": [
+         "ocamlbuild",
+         "ocamlfind",
+         "topkg"
+       ]
+     },
+     "fpath": {
+       "version": "0.7.3",
+       "src": {
+         "url": "https://erratique.ch/software/fpath/releases/fpath-0.7.3.tbz",
+         "sha256": "12b08ff192d037d9b6d69e9ca19d1d385184f20b3237c27231e437ac81ace70f"
+       },
+       "depends": [
+         "astring",
+         "ocaml"
+       ],
+       "build-depends": [
+         "ocamlbuild",
+         "ocamlfind",
+         "topkg"
+       ]
+     },
+     "gcloud": {
+       "version": "dev",
+       "src": { "url": "file://." },
+       "depends": [
+         "base64",
+         "cohttp",
+         "cohttp-lwt-unix",
+         "containers",
+         "cstruct",
+         "dune",
+         "ezgzip",
+         "jose",
+         "logs",
+         "lwt",
+         "ppx_deriving_yojson",
+         "x509",
+         "yojson"
+       ],
+       "build-depends": [
+         "dune"
+       ],
+       "test-depends": [
+         "alcotest",
+         "alcotest-lwt",
+         "ppx_here",
+         "tls"
+       ],
+       "dev-setup-depends": [
+         "ocaml-lsp-server",
+         "utop"
+       ],
+       "vars": { "with-test": true, "with-dev-setup": true }
+     },
+     "gcloud-cli": {
+       "version": "dev",
+       "src": { "url": "file://." },
+       "depends": [
+         "cmdliner",
+         "cohttp",
+         "dune",
+         "gcloud",
+         "logs",
+         "tls-lwt"
+       ],
+       "build-depends": [
+         "dune"
+       ],
+       "vars": { "with-test": true, "with-dev-setup": true }
+     },
+     "gcloud-melange": {
+       "version": "dev",
+       "src": { "url": "file://." },
+       "depends": [
+         "dune",
+         "melange"
+       ],
+       "build-depends": [
+         "dune"
+       ],
+       "vars": { "with-test": true, "with-dev-setup": true }
+     },
+     "gmap": {
+       "version": "0.3.0",
+       "src": {
+         "url": "https://github.com/hannesm/gmap/releases/download/0.3.0/gmap-0.3.0.tbz",
+         "sha256": "04dd9e6226ac8f8fb4ccb6021048702e34a482fb9c1d240d3852829529507c1c"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "hkdf": {
+       "version": "1.0.4",
+       "src": {
+         "url": "https://github.com/hannesm/ocaml-hkdf/releases/download/v1.0.4/hkdf-v1.0.4.tbz",
+         "sha256": "b926d6da4ac45aab999735dd2bbfd1f7511316710d791afa361006b6fe36fd5b"
+       },
+       "depends": [
+         "cstruct",
+         "dune",
+         "mirage-crypto",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "host-arch-unknown": {
+       "version": "1"
+     },
+     "ipaddr": {
+       "version": "5.6.0",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.6.0/ipaddr-5.6.0.tbz",
+         "sha256": "9e30433fdb4ca437a6aa8ffb447baca5eba7615fb88e7b0cd8a4b416c3208133"
+       },
+       "depends": [
+         "domain-name",
+         "dune",
+         "macaddr",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ipaddr-sexp": {
+       "version": "5.6.0",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.6.0/ipaddr-5.6.0.tbz",
+         "sha256": "9e30433fdb4ca437a6aa8ffb447baca5eba7615fb88e7b0cd8a4b416c3208133"
+       },
+       "depends": [
+         "dune",
+         "ipaddr",
+         "ocaml",
+         "ppx_sexp_conv",
+         "sexplib0"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "jose": {
+       "version": "0.9.0",
+       "src": {
+         "url": "https://github.com/ulrikstrid/reason-jose/releases/download/v0.9.0/jose-v0.9.0.tbz",
+         "sha256": "c449a63c53043deb149cfc1305e578971bb5b460f17b4a66e286e826f2dbc18d"
+       },
+       "depends": [
+         "astring",
+         "base64",
+         "cstruct",
+         "dune",
+         "eqaf",
+         "mirage-crypto",
+         "ocaml",
+         "ptime",
+         "x509",
+         "yojson",
+         "zarith"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "jsonm": {
+       "version": "1.0.2",
+       "src": {
+         "url": "https://erratique.ch/software/jsonm/releases/jsonm-1.0.2.tbz",
+         "sha512": "0072f5c31080202ed1cb996a8530d72c882723f26b597f784441033f59338ba8c0cbabf901794d5b1ae749a54af4d7ebf7b47987db43488c7f6ac7fe191a042f"
+       },
+       "depends": [
+         "ocaml",
+         "uutf"
+       ],
+       "build-depends": [
+         "ocamlbuild",
+         "ocamlfind",
+         "topkg"
+       ]
+     },
+     "jsonrpc": {
+       "version": "1.19.0",
+       "src": {
+         "url": "https://github.com/ocaml/ocaml-lsp/releases/download/1.19.0/lsp-1.19.0.tbz",
+         "sha256": "e783d9f1a7f89ce1bf4c9148aa34a228368bd149bbcca43de80b459221dee5ec"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "lambda-term": {
+       "version": "3.3.2",
+       "src": {
+         "url": "https://github.com/ocaml-community/lambda-term/archive/refs/tags/3.3.2.tar.gz",
+         "sha512": "78648768644058337e22c79cf1fbb1a36472b24f11b1dc0461fc38419be6ec01b02d8d0ac45fed0bc99f91ba4c0f19d3bda113e834e064bee973b734527b9766"
+       },
+       "depends": [
+         "dune",
+         "logs",
+         "lwt",
+         "lwt_react",
+         "mew_vi",
+         "ocaml",
+         "react",
+         "zed"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "logs": {
+       "version": "0.7.0",
+       "src": {
+         "url": "https://erratique.ch/software/logs/releases/logs-0.7.0.tbz",
+         "sha256": "86f4a02807eb1a297aae44977d9f61e419c31458a5d7b23c6f55575e8e69d5ca"
+       },
+       "depends": [
+         "base-threads",
+         "cmdliner",
+         "fmt",
+         "lwt",
+         "ocaml"
+       ],
+       "build-depends": [
+         "ocamlbuild",
+         "ocamlfind",
+         "topkg"
+       ]
+     },
+     "lsp": {
+       "version": "1.19.0",
+       "src": {
+         "url": "https://github.com/ocaml/ocaml-lsp/releases/download/1.19.0/lsp-1.19.0.tbz",
+         "sha256": "e783d9f1a7f89ce1bf4c9148aa34a228368bd149bbcca43de80b459221dee5ec"
+       },
+       "depends": [
+         "dune",
+         "jsonrpc",
+         "ocaml",
+         "ppx_yojson_conv_lib",
+         "uutf",
+         "yojson"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "lwt": {
+       "version": "5.8.0",
+       "src": {
+         "url": "https://github.com/ocsigen/lwt/archive/refs/tags/5.8.0.tar.gz",
+         "sha512": "7f6548a1b1dbfdbc98d9352151ca7be97fa2ab63dbcc429208ce8d08308eee13f7fce31e0cca53f8880233959a60212d622270dd51bf164c3ee272f179769bd9"
+       },
+       "depends": [
+         "base-threads",
+         "base-unix",
+         "dune",
+         "dune-configurator",
+         "ocaml",
+         "ocplib-endian"
+       ],
+       "build-depends": [
+         "cppo",
+         "dune",
+         "dune-configurator"
+       ]
+     },
+     "lwt_react": {
+       "version": "1.2.0",
+       "src": {
+         "url": "https://github.com/ocsigen/lwt/archive/5.6.0.tar.gz",
+         "sha512": "d616389bc9e0da11f25843ab7541ac2d40c9543700a89455f14115b339bbe58cef2b8acf0ae97fd54e15a4cb93149cfe1ebfda301aa93933045f76b7d9344160"
+       },
+       "depends": [
+         "dune",
+         "lwt",
+         "ocaml",
+         "react"
+       ],
+       "build-depends": [
+         "cppo",
+         "dune"
+       ]
+     },
+     "macaddr": {
+       "version": "5.6.0",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.6.0/ipaddr-5.6.0.tbz",
+         "sha256": "9e30433fdb4ca437a6aa8ffb447baca5eba7615fb88e7b0cd8a4b416c3208133"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "magic-mime": {
+       "version": "1.3.1",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-magic-mime/releases/download/v1.3.1/magic-mime-1.3.1.tbz",
+         "sha256": "e0234d03625dba1efac58e57e387672d75a5e9a621ff49acfe0f609c00f13b08"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "melange": {
+       "version": "4.0.1-52",
+       "src": {
+         "url": "https://github.com/melange-re/melange/releases/download/4.0.1-52/melange-4.0.1-52.tbz",
+         "sha256": "91494286a42d2d7ef387dd062b6de26ccab223f308a74b0c60b8e43d7f6f7537"
+       },
+       "depends": [
+         "cmdliner",
+         "dune",
+         "dune-build-info",
+         "menhir",
+         "ocaml",
+         "ppxlib"
+       ],
+       "build-depends": [
+         "cppo",
+         "dune",
+         "menhir"
+       ]
+     },
+     "menhir": {
+       "version": "20240715",
+       "src": {
+         "url": "https://gitlab.inria.fr/fpottier/menhir/-/archive/20240715/archive.tar.gz",
+         "sha512": "4f933cfc9026f5f2ffda9b0e626862560a233c35ecf097d179edd926d9009bdf46b6611294aea02b63c34427348568f37376a033fbe8cf98a7746fa6f1354dbd"
+       },
+       "depends": [
+         "dune",
+         "menhirCST",
+         "menhirLib",
+         "menhirSdk",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "menhirCST": {
+       "version": "20240715",
+       "src": {
+         "url": "https://gitlab.inria.fr/fpottier/menhir/-/archive/20240715/archive.tar.gz",
+         "sha512": "4f933cfc9026f5f2ffda9b0e626862560a233c35ecf097d179edd926d9009bdf46b6611294aea02b63c34427348568f37376a033fbe8cf98a7746fa6f1354dbd"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "menhirLib": {
+       "version": "20240715",
+       "src": {
+         "url": "https://gitlab.inria.fr/fpottier/menhir/-/archive/20240715/archive.tar.gz",
+         "sha512": "4f933cfc9026f5f2ffda9b0e626862560a233c35ecf097d179edd926d9009bdf46b6611294aea02b63c34427348568f37376a033fbe8cf98a7746fa6f1354dbd"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "menhirSdk": {
+       "version": "20240715",
+       "src": {
+         "url": "https://gitlab.inria.fr/fpottier/menhir/-/archive/20240715/archive.tar.gz",
+         "sha512": "4f933cfc9026f5f2ffda9b0e626862560a233c35ecf097d179edd926d9009bdf46b6611294aea02b63c34427348568f37376a033fbe8cf98a7746fa6f1354dbd"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "merlin-lib": {
+       "version": "5.2.1-502",
+       "src": {
+         "url": "https://github.com/ocaml/merlin/releases/download/v5.2.1-502/merlin-5.2.1-502.tbz",
+         "sha256": "5c02dc71b2d31b619851c14a965b91c650a4dbcd49bf56004eee61e0c58d584c"
+       },
+       "depends": [
+         "csexp",
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "mew": {
+       "version": "0.1.0",
+       "src": {
+         "url": "https://github.com/kandu/mew/archive/0.1.0.tar.gz",
+         "sha256": "64d38ceb52ef574cb314bdd693f7e4a9c9e483e80a58595db22f2df76a8a59e6"
+       },
+       "depends": [
+         "dune",
+         "ocaml",
+         "result",
+         "trie"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "mew_vi": {
+       "version": "0.5.0",
+       "src": {
+         "url": "https://github.com/kandu/mew_vi/archive/0.5.0.tar.gz",
+         "sha256": "a692fa7cdcc9e80fd9387c4f61677776b9fc15f9f7175b4220fcd1a73d1bafda"
+       },
+       "depends": [
+         "dune",
+         "mew",
+         "ocaml",
+         "react"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "mirage-crypto": {
+       "version": "0.11.3",
+       "src": {
+         "url": "https://github.com/mirage/mirage-crypto/releases/download/v0.11.3/mirage-crypto-0.11.3.tbz",
+         "sha256": "bfb530fa169cd905ebc7e2449f3407cfbd67023ac0b291b8b6f4a1437a5d95b1"
+       },
+       "depends": [
+         "cstruct",
+         "dune",
+         "dune-configurator",
+         "eqaf",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune",
+         "dune-configurator"
+       ]
+     },
+     "mirage-crypto-ec": {
+       "version": "0.11.3",
+       "src": {
+         "url": "https://github.com/mirage/mirage-crypto/releases/download/v0.11.3/mirage-crypto-0.11.3.tbz",
+         "sha256": "bfb530fa169cd905ebc7e2449f3407cfbd67023ac0b291b8b6f4a1437a5d95b1"
+       },
+       "depends": [
+         "cstruct",
+         "dune",
+         "dune-configurator",
+         "eqaf",
+         "mirage-crypto",
+         "mirage-crypto-rng",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune",
+         "dune-configurator"
+       ]
+     },
+     "mirage-crypto-pk": {
+       "version": "0.11.3",
+       "src": {
+         "url": "https://github.com/mirage/mirage-crypto/releases/download/v0.11.3/mirage-crypto-0.11.3.tbz",
+         "sha256": "bfb530fa169cd905ebc7e2449f3407cfbd67023ac0b291b8b6f4a1437a5d95b1"
+       },
+       "depends": [
+         "cstruct",
+         "dune",
+         "eqaf",
+         "mirage-crypto",
+         "mirage-crypto-rng",
+         "ocaml",
+         "sexplib0",
+         "zarith"
+       ],
+       "build-depends": [
+         "conf-gmp-powm-sec",
+         "dune"
+       ]
+     },
+     "mirage-crypto-rng": {
+       "version": "0.11.3",
+       "src": {
+         "url": "https://github.com/mirage/mirage-crypto/releases/download/v0.11.3/mirage-crypto-0.11.3.tbz",
+         "sha256": "bfb530fa169cd905ebc7e2449f3407cfbd67023ac0b291b8b6f4a1437a5d95b1"
+       },
+       "depends": [
+         "cstruct",
+         "dune",
+         "dune-configurator",
+         "duration",
+         "logs",
+         "mirage-crypto",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune",
+         "dune-configurator"
+       ]
+     },
+     "mirage-crypto-rng-lwt": {
+       "version": "0.11.3",
+       "src": {
+         "url": "https://github.com/mirage/mirage-crypto/releases/download/v0.11.3/mirage-crypto-0.11.3.tbz",
+         "sha256": "bfb530fa169cd905ebc7e2449f3407cfbd67023ac0b291b8b6f4a1437a5d95b1"
+       },
+       "depends": [
+         "dune",
+         "duration",
+         "logs",
+         "lwt",
+         "mirage-crypto",
+         "mirage-crypto-rng",
+         "mtime",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "mtime": {
+       "version": "2.1.0",
+       "src": {
+         "url": "https://erratique.ch/software/mtime/releases/mtime-2.1.0.tbz",
+         "sha512": "a6619f1a3f1a5b32b7a9a067b939f94e6c66244eb90762d41f2cb1c9af852dd7d270fedb20e2b9b61875d52ba46e24af6ebf5950d1284b0b75b2fd2c380d9af3"
+       },
+       "depends": [
+         "ocaml"
+       ],
+       "build-depends": [
+         "ocamlbuild",
+         "ocamlfind",
+         "topkg"
+       ]
+     },
+     "num": {
+       "version": "1.5-1",
+       "src": {
+         "url": "https://github.com/ocaml/num/archive/v1.5.tar.gz",
+         "sha512": "110dd01140c1c96f5f067aa824bb63f74a26411dcaa65aaf04cb6c44b116ca02aaab9505f431c66964388ce4a31d86da5928b4c0e5557800e834de80bed46495"
+       },
+       "src-extra": {
+         "num-in-findlib-dir.patch": {
+           "url": "https://github.com/ocaml/num/commit/f6e31b1653f32c7c425b69c2b123ab2f924a4d61.patch?full_index=1",
+           "sha256": "f93880031ed823249f4aac860e0d9e5cdc2878550db13914db25b1585803cf05"
+         }
+       },
+       "depends": [
+         "ocaml"
+       ]
+     },
+     "ocaml": {
+       "version": "5.2.0",
+       "depends": [
+         "ocaml-config",
+         "ocaml-system"
+       ],
+       "build-depends": [
+         "ocaml-system"
+       ]
+     },
+     "ocaml-compiler-libs": {
+       "version": "v0.17.0",
+       "src": {
+         "url": "https://github.com/janestreet/ocaml-compiler-libs/archive/refs/tags/v0.17.0.tar.gz",
+         "sha512": "c5cd418b0eb74e00c3f63235754bbdb3a3328ac743d6ae885424d8c50b4edaa7068572e689cb3456d222793283927f2984a1ff840b1bc3817f810b5314faf897"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ocaml-config": {
+       "version": "3",
+       "src-extra": {
+         "gen_ocaml_config.ml.in": {
+           "url": "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-config/gen_ocaml_config.ml.in.3",
+           "sha256": "a9ad8d84a08961159653a978db92d10f694510182b206cacb96d5c9f63b5121e"
+         },
+         "ocaml-config.install": {
+           "url": "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-config/ocaml-config.install",
+           "sha256": "6e4fd93f4cce6bad0ed3c08afd0248dbe7d7817109281de6294e5b5ef5597051"
+         }
+       },
+       "depends": [
+         "ocaml-system"
+       ],
+       "build-depends": [
+         "ocaml-system"
+       ]
+     },
+     "ocaml-index": {
+       "version": "1.1",
+       "src": {
+         "url": "https://github.com/ocaml/merlin/releases/download/v5.2.1-502/merlin-5.2.1-502.tbz",
+         "sha256": "5c02dc71b2d31b619851c14a965b91c650a4dbcd49bf56004eee61e0c58d584c"
+       },
+       "depends": [
+         "dune",
+         "merlin-lib",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ocaml-lsp-server": {
+       "version": "1.19.0",
+       "src": {
+         "url": "https://github.com/ocaml/ocaml-lsp/releases/download/1.19.0/lsp-1.19.0.tbz",
+         "sha256": "e783d9f1a7f89ce1bf4c9148aa34a228368bd149bbcca43de80b459221dee5ec"
+       },
+       "depends": [
+         "astring",
+         "base",
+         "camlp-streams",
+         "chrome-trace",
+         "csexp",
+         "dune",
+         "dune-build-info",
+         "dune-rpc",
+         "dyn",
+         "fiber",
+         "jsonrpc",
+         "lsp",
+         "merlin-lib",
+         "ocaml",
+         "ocamlc-loc",
+         "ocamlformat-rpc-lib",
+         "ordering",
+         "pp",
+         "ppx_yojson_conv_lib",
+         "re",
+         "spawn",
+         "stdune",
+         "xdg",
+         "yojson"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ocaml-syntax-shims": {
+       "version": "1.0.0",
+       "src": {
+         "url": "https://github.com/ocaml-ppx/ocaml-syntax-shims/releases/download/1.0.0/ocaml-syntax-shims-1.0.0.tbz",
+         "sha256": "89b2e193e90a0c168b6ec5ddf6fef09033681bdcb64e11913c97440a2722e8c8"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ocaml-system": {
+       "version": "5.2.0",
+       "src-extra": {
+         "gen_ocaml_config.ml.in": {
+           "url": "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-system/gen_ocaml_config.ml.in",
+           "sha256": "71bcd3d35e28cbf71eda81991c8741268f4b87ced71573b2e75f64f136cebfc1"
+         }
+       },
+       "depends": [
+         "host-arch-unknown"
+       ],
+       "depexts": [
+         "ocaml-ng.ocamlPackages_5_2.ocaml"
+       ]
+     },
+     "ocaml_intrinsics_kernel": {
+       "version": "v0.17.1",
+       "src": {
+         "url": "https://github.com/janestreet/ocaml_intrinsics_kernel/archive/refs/tags/v0.17.1.tar.gz",
+         "sha512": "21e596d6407a620866cee7cab47ef1a9446d6a733b4994e809ea5566d5fa956682a5c6a6190ffb0ed48458abd658301944ed10c4389d91ecb8df677a5f87f2ab"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ocamlbuild": {
+       "version": "0.15.0",
+       "src": {
+         "url": "https://github.com/ocaml/ocamlbuild/archive/refs/tags/0.15.0.tar.gz",
+         "sha512": "c8311a9a78491bf759eb27153d6ba4692d27cd935759a145f96a8ba8f3c2e97cef54e7d654ed1c2c07c74f60482a4fef5224e26d0f04450e69cdcb9418c762d3"
+       },
+       "depends": [
+         "ocaml"
+       ]
+     },
+     "ocamlc-loc": {
+       "version": "3.16.0",
+       "src": {
+         "url": "https://github.com/ocaml/dune/releases/download/3.16.0/dune-3.16.0.tbz",
+         "sha256": "5481dde7918ca3121e02c34d74339f734b32d5883efb8c1b8056471e74f9bda6"
+       },
+       "depends": [
+         "dune",
+         "dyn",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ocamlfind": {
+       "version": "1.9.6",
+       "src": {
+         "url": "http://download.camlcity.org/download/findlib-1.9.6.tar.gz",
+         "sha512": "cfaf1872d6ccda548f07d32cc6b90c3aafe136d2aa6539e03143702171ee0199add55269bba894c77115535dc46a5835901a5d7c75768999e72db503bfd83027"
+       },
+       "src-extra": {
+         "0001-Harden-test-for-OCaml-5.patch": {
+           "url": "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocamlfind/0001-Harden-test-for-OCaml-5.patch",
+           "sha256": "6fcca5f2f7abf8d6304da6c385348584013ffb8602722a87fb0bacbab5867fe8"
+         }
+       },
+       "depends": [
+         "ocaml"
+       ]
+     },
+     "ocamlformat-rpc-lib": {
+       "version": "0.26.2",
+       "src": {
+         "url": "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.26.2/ocamlformat-0.26.2.tbz",
+         "sha256": "2e4f596bf7aa367a844fe83ba0f6b0bf14b2a65179ddc082363fe9793d0375c5"
+       },
+       "depends": [
+         "csexp",
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ocplib-endian": {
+       "version": "1.2",
+       "src": {
+         "url": "https://github.com/OCamlPro/ocplib-endian/archive/refs/tags/1.2.tar.gz",
+         "sha512": "2e70be5f3d6e377485c60664a0e235c3b9b24a8d6b6a03895d092c6e40d53810bfe1f292ee69e5181ce6daa8a582bfe3d59f3af889f417134f658812be5b8b85"
+       },
+       "depends": [
+         "base-bytes",
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "cppo",
+         "dune"
+       ]
+     },
+     "ordering": {
+       "version": "3.16.0",
+       "src": {
+         "url": "https://github.com/ocaml/dune/releases/download/3.16.0/dune-3.16.0.tbz",
+         "sha256": "5481dde7918ca3121e02c34d74339f734b32d5883efb8c1b8056471e74f9bda6"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "parsexp": {
+       "version": "v0.17.0",
+       "src": {
+         "url": "https://github.com/janestreet/parsexp/archive/refs/tags/v0.17.0.tar.gz",
+         "sha256": "a3d10edbc4f98d16357b644d550fd1c06f4d9aa4990ab8ee6da01276c24d55b5"
+       },
+       "depends": [
+         "dune",
+         "ocaml",
+         "sexplib0"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "pbkdf": {
+       "version": "1.2.0",
+       "src": {
+         "url": "https://github.com/abeaumont/ocaml-pbkdf/archive/1.2.0.tar.gz",
+         "sha512": "d6f7d5efd761b87dd420ddcf97c2f9d4402dcc81d65cd1f4d81039b70c4d8c1e803bbaf4251482de8de7076da9f40b48c7eb1684e31e7a316deb5036c192bd3c"
+       },
+       "depends": [
+         "cstruct",
+         "dune",
+         "mirage-crypto",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "pp": {
+       "version": "1.2.0",
+       "src": {
+         "url": "https://github.com/ocaml-dune/pp/releases/download/1.2.0/pp-1.2.0.tbz",
+         "sha256": "a5e822573c55afb42db29ec56eacd1f2acd8f65cf2df2878e291de374ce6909c"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ppx_derivers": {
+       "version": "1.2.1",
+       "src": {
+         "url": "https://github.com/ocaml-ppx/ppx_derivers/archive/1.2.1.tar.gz",
+         "sha256": "b6595ee187dea792b31fc54a0e1524ab1e48bc6068d3066c45215a138cc73b95"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ppx_deriving": {
+       "version": "6.0.3",
+       "src": {
+         "url": "https://github.com/ocaml-ppx/ppx_deriving/releases/download/v6.0.3/ppx_deriving-6.0.3.tbz",
+         "sha256": "374aa97b32c5e01c09a97810a48bfa218c213b5b649e4452101455ac19c94a6d"
+       },
+       "depends": [
+         "dune",
+         "ocaml",
+         "ocamlfind",
+         "ppx_derivers",
+         "ppxlib"
+       ],
+       "build-depends": [
+         "cppo",
+         "dune",
+         "ocamlfind"
+       ]
+     },
+     "ppx_deriving_yojson": {
+       "version": "3.9.0",
+       "src": {
+         "url": "https://github.com/ocaml-ppx/ppx_deriving_yojson/releases/download/v3.9.0/ppx_deriving_yojson-3.9.0.tbz",
+         "sha256": "6745f4f6615c918b0b00296161e0da20c1a6b2b8650bf1b7a5313f94171c4047"
+       },
+       "depends": [
+         "dune",
+         "ocaml",
+         "ppx_deriving",
+         "ppxlib",
+         "yojson"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ppx_here": {
+       "version": "v0.17.0",
+       "src": {
+         "url": "https://github.com/janestreet/ppx_here/archive/refs/tags/v0.17.0.tar.gz",
+         "sha256": "27ac69db34a5ff0efbf6e3c52d52dda46d1e5d5db4d14fb4d8c20370b932a913"
+       },
+       "depends": [
+         "base",
+         "dune",
+         "ocaml",
+         "ppxlib"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ppx_sexp_conv": {
+       "version": "v0.17.0",
+       "src": {
+         "url": "https://github.com/janestreet/ppx_sexp_conv/archive/refs/tags/v0.17.0.tar.gz",
+         "sha256": "4af4f99d774fab77bf63ba2298fc288c356a88bdac0a37e3a23b0d669410ee5a"
+       },
+       "depends": [
+         "base",
+         "dune",
+         "ocaml",
+         "ppxlib",
+         "ppxlib_jane",
+         "sexplib0"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ppx_yojson_conv_lib": {
+       "version": "v0.17.0",
+       "src": {
+         "url": "https://github.com/janestreet/ppx_yojson_conv_lib/archive/refs/tags/v0.17.0.tar.gz",
+         "sha256": "f6e6ee92408c53c5ecd8bb5ae93811aa4cf71f8dc144d5943be8fc2c7697b199"
+       },
+       "depends": [
+         "dune",
+         "ocaml",
+         "yojson"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ppxlib": {
+       "version": "0.33.1~5.3preview",
+       "src": {
+         "url": "https://github.com/ocaml-ppx/ppxlib/archive/ac7fcfc88d574609b62cc0a38e0de59d03cc96de.tar.gz",
+         "sha256": "d679f110b92ed12156556ee1d3779d11cef605c36f0bc417943e7996f0d2bbaf"
+       },
+       "depends": [
+         "dune",
+         "ocaml",
+         "ocaml-compiler-libs",
+         "ppx_derivers",
+         "sexplib0",
+         "stdlib-shims"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ppxlib_jane": {
+       "version": "v0.17.0",
+       "src": {
+         "url": "https://github.com/janestreet/ppxlib_jane/archive/refs/tags/v0.17.0.tar.gz",
+         "sha256": "42757d7b44a5f2a766778e6b4710100c6ef9d0c074eb3e7fa4c69647336d8398"
+       },
+       "depends": [
+         "dune",
+         "ocaml",
+         "ppxlib"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ptime": {
+       "version": "1.2.0",
+       "src": {
+         "url": "https://erratique.ch/software/ptime/releases/ptime-1.2.0.tbz",
+         "sha512": "b0c3240dd9e777a5e60b5269eb2e312fc644d29ef55e257d2f2538c03bf62274173ed36e13858c44d2dbee8fe375c9c483e705706e4aa5b3b5c4609ca6324a5c"
+       },
+       "depends": [
+         "ocaml"
+       ],
+       "build-depends": [
+         "ocamlbuild",
+         "ocamlfind",
+         "topkg"
+       ]
+     },
+     "re": {
+       "version": "1.12.0",
+       "src": {
+         "url": "https://github.com/ocaml/ocaml-re/releases/download/1.12.0/re-1.12.0.tbz",
+         "sha256": "a01f2bf22f72c2f4ababd8d3e7635e35c1bf6bc5a41ad6d5a007454ddabad1d4"
+       },
+       "depends": [
+         "dune",
+         "ocaml",
+         "seq"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "react": {
+       "version": "1.2.2",
+       "src": {
+         "url": "https://erratique.ch/software/react/releases/react-1.2.2.tbz",
+         "sha512": "18cdd544d484222ba02db6bd9351571516532e7a1c107b59bbe39193837298f5c745eab6754f8bc6ff125b387be7018c6d6e6ac99f91925a5e4f53af688522b1"
+       },
+       "depends": [
+         "ocaml"
+       ],
+       "build-depends": [
+         "ocamlbuild",
+         "ocamlfind",
+         "topkg"
+       ]
+     },
+     "result": {
+       "version": "1.5",
+       "src": {
+         "url": "https://github.com/janestreet/result/releases/download/1.5/result-1.5.tbz",
+         "sha256": "7c3a5e238558f4c1a4f5acca816bc705a0e12f68dc0005c61ddbf2e6cab8ee32"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "rresult": {
+       "version": "0.7.0",
+       "src": {
+         "url": "https://erratique.ch/software/rresult/releases/rresult-0.7.0.tbz",
+         "sha512": "f1bb631c986996388e9686d49d5ae4d8aaf14034f6865c62a88fb58c48ce19ad2eb785327d69ca27c032f835984e0bd2efd969b415438628a31f3e84ec4551d3"
+       },
+       "depends": [
+         "ocaml"
+       ],
+       "build-depends": [
+         "ocamlbuild",
+         "ocamlfind",
+         "topkg"
+       ]
+     },
+     "seq": {
+       "version": "base",
+       "src-extra": {
+         "META.seq": {
+           "url": "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/seq/META.seq",
+           "sha256": "e95062b4d0519ef8335c02f7d0f1952d11b814c7ab7e6d566a206116162fa2be"
+         },
+         "seq.install": {
+           "url": "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/seq/seq.install",
+           "sha256": "fff926c2c4d5a82b6c94c60c4c35eb06e3d39975893ebe6b1f0e6557cbe34904"
+         }
+       },
+       "depends": [
+         "ocaml"
+       ]
+     },
+     "sexplib": {
+       "version": "v0.17.0",
+       "src": {
+         "url": "https://github.com/janestreet/sexplib/archive/refs/tags/v0.17.0.tar.gz",
+         "sha256": "da863b42b81235fdcf45eb32c04fb8bde22ff446a779cfb6f989730a35103160"
+       },
+       "depends": [
+         "dune",
+         "num",
+         "ocaml",
+         "parsexp",
+         "sexplib0"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "sexplib0": {
+       "version": "v0.17.0",
+       "src": {
+         "url": "https://github.com/janestreet/sexplib0/archive/refs/tags/v0.17.0.tar.gz",
+         "sha512": "ad387e40789fe70a11473db7e85fe017b801592624414e9030730b2e92ea08f98095fb6e9236430f33c801605ebee0a2a6284e0f618a26a7da4599d4fd9d395d"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "spawn": {
+       "version": "v0.15.1",
+       "src": {
+         "url": "https://github.com/janestreet/spawn/archive/v0.15.1.tar.gz",
+         "sha256": "9afdee314fab6c3fcd689ab6eb5608d6b78078e6dede3953a47debde06c19d50"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "stdlib-shims": {
+       "version": "0.3.0",
+       "src": {
+         "url": "https://github.com/ocaml/stdlib-shims/releases/download/0.3.0/stdlib-shims-0.3.0.tbz",
+         "sha256": "babf72d3917b86f707885f0c5528e36c63fccb698f4b46cf2bab5c7ccdd6d84a"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "stdune": {
+       "version": "3.16.0",
+       "src": {
+         "url": "https://github.com/ocaml/dune/releases/download/3.16.0/dune-3.16.0.tbz",
+         "sha256": "5481dde7918ca3121e02c34d74339f734b32d5883efb8c1b8056471e74f9bda6"
+       },
+       "depends": [
+         "base-unix",
+         "csexp",
+         "dune",
+         "dyn",
+         "ocaml",
+         "ordering",
+         "pp"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "stringext": {
+       "version": "1.6.0",
+       "src": {
+         "url": "https://github.com/rgrinberg/stringext/releases/download/1.6.0/stringext-1.6.0.tbz",
+         "sha256": "db41f5d52e9eab17615f110b899dfeb27dd7e7f89cd35ae43827c5119db206ea"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "tls": {
+       "version": "0.17.5",
+       "src": {
+         "url": "https://github.com/mirleft/ocaml-tls/releases/download/v0.17.5/tls-0.17.5.tbz",
+         "sha256": "89108857bf3a6f85722925a8d4a3f59c291d638c0f2e2fc45f0fdaf892ae4819"
+       },
+       "depends": [
+         "cstruct",
+         "domain-name",
+         "dune",
+         "fmt",
+         "hkdf",
+         "ipaddr",
+         "logs",
+         "mirage-crypto",
+         "mirage-crypto-ec",
+         "mirage-crypto-pk",
+         "mirage-crypto-rng",
+         "ocaml",
+         "x509"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "tls-lwt": {
+       "version": "0.17.5",
+       "src": {
+         "url": "https://github.com/mirleft/ocaml-tls/releases/download/v0.17.5/tls-0.17.5.tbz",
+         "sha256": "89108857bf3a6f85722925a8d4a3f59c291d638c0f2e2fc45f0fdaf892ae4819"
+       },
+       "depends": [
+         "cmdliner",
+         "dune",
+         "lwt",
+         "mirage-crypto-rng-lwt",
+         "ocaml",
+         "ptime",
+         "tls",
+         "x509"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "topkg": {
+       "version": "1.0.7",
+       "src": {
+         "url": "https://erratique.ch/software/topkg/releases/topkg-1.0.7.tbz",
+         "sha512": "09e59f1759bf4db8471f02d0aefd8db602b44932a291c05c312b1423796e7a15d1598d3c62a0cec7f083eff8e410fac09363533dc4bd2120914bb9664efea535"
+       },
+       "depends": [
+         "ocaml",
+         "ocamlbuild"
+       ],
+       "build-depends": [
+         "ocamlbuild",
+         "ocamlfind"
+       ]
+     },
+     "trie": {
+       "version": "1.0.0",
+       "src": {
+         "url": "https://github.com/kandu/trie/archive/1.0.0.tar.gz",
+         "sha256": "c2f8054ea44216e6a3a961b28f7630e0e3dbfbd1b504ae741be230cbe32498ea"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "uchar": {
+       "version": "0.0.2",
+       "src": {
+         "url": "https://github.com/ocaml/uchar/releases/download/v0.0.2/uchar-0.0.2.tbz",
+         "sha256": "47397f316cbe76234af53c74a1f9452154ba3bdb54fced5caac959f50f575af0"
+       },
+       "depends": [
+         "ocaml"
+       ],
+       "build-depends": [
+         "ocamlbuild"
+       ]
+     },
+     "uri": {
+       "version": "4.4.0",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-uri/releases/download/v4.4.0/uri-4.4.0.tbz",
+         "sha256": "cdabaf6ef5cd2161e59cc7b74c6e4a68ecb80a9f4e96002e338e1b6bf17adec4"
+       },
+       "depends": [
+         "angstrom",
+         "dune",
+         "ocaml",
+         "stringext"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "uri-sexp": {
+       "version": "4.4.0",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-uri/releases/download/v4.4.0/uri-4.4.0.tbz",
+         "sha256": "cdabaf6ef5cd2161e59cc7b74c6e4a68ecb80a9f4e96002e338e1b6bf17adec4"
+       },
+       "depends": [
+         "dune",
+         "ppx_sexp_conv",
+         "sexplib0",
+         "uri"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "utop": {
+       "version": "2.14.0",
+       "src": {
+         "url": "https://github.com/ocaml-community/utop/releases/download/2.14.0/utop-2.14.0.tbz",
+         "sha256": "0fd5a9bc5b458524a71463a1fe0cd16f9b7be13673ae303118b7216e0d273ba9"
+       },
+       "depends": [
+         "base-threads",
+         "base-unix",
+         "cppo",
+         "dune",
+         "lambda-term",
+         "logs",
+         "lwt",
+         "lwt_react",
+         "ocaml",
+         "ocamlfind",
+         "react",
+         "xdg",
+         "zed"
+       ],
+       "build-depends": [
+         "cppo",
+         "dune",
+         "ocamlfind"
+       ]
+     },
+     "uucp": {
+       "version": "16.0.0",
+       "src": {
+         "url": "https://erratique.ch/software/uucp/releases/uucp-16.0.0.tbz",
+         "sha512": "5c06d8cadb2b011b1e4ac52e14732044f6ab8e9c11e1184950ff8629b26bd173f1264247623a635b8aa4033e287bfe42d709994f19a3d79f7cbfd20158aa4992"
+       },
+       "depends": [
+         "cmdliner",
+         "ocaml"
+       ],
+       "build-depends": [
+         "ocamlbuild",
+         "ocamlfind",
+         "topkg"
+       ]
+     },
+     "uuseg": {
+       "version": "16.0.0",
+       "src": {
+         "url": "https://erratique.ch/software/uuseg/releases/uuseg-16.0.0.tbz",
+         "sha512": "355139aee2a72baddf3d811e522948456147546ee946b6eca20f57711865770d4b8d32ea01a7338b8e6cdedb4423ee65cee387704bb9c0c057bcbd65012679b8"
+       },
+       "depends": [
+         "cmdliner",
+         "ocaml",
+         "uucp",
+         "uutf"
+       ],
+       "build-depends": [
+         "ocamlbuild",
+         "ocamlfind",
+         "topkg"
+       ]
+     },
+     "uutf": {
+       "version": "1.0.3",
+       "src": {
+         "url": "https://erratique.ch/software/uutf/releases/uutf-1.0.3.tbz",
+         "sha512": "50cc4486021da46fb08156e9daec0d57b4ca469b07309c508d5a9a41e9dbcf1f32dec2ed7be027326544453dcaf9c2534919395fd826dc7768efc6cc4bfcc9f8"
+       },
+       "depends": [
+         "cmdliner",
+         "ocaml"
+       ],
+       "build-depends": [
+         "ocamlbuild",
+         "ocamlfind",
+         "topkg"
+       ]
+     },
+     "x509": {
+       "version": "0.16.5",
+       "src": {
+         "url": "https://github.com/mirleft/ocaml-x509/releases/download/v0.16.5/x509-0.16.5.tbz",
+         "sha256": "149e25a5fea37f619fb2690bee5c00f01c9dcf31d335f8ffcaab39a7538ccd99"
+       },
+       "depends": [
+         "asn1-combinators",
+         "base64",
+         "cstruct",
+         "domain-name",
+         "dune",
+         "fmt",
+         "gmap",
+         "ipaddr",
+         "logs",
+         "mirage-crypto",
+         "mirage-crypto-ec",
+         "mirage-crypto-pk",
+         "mirage-crypto-rng",
+         "ocaml",
+         "pbkdf",
+         "ptime"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "xdg": {
+       "version": "3.16.0",
+       "src": {
+         "url": "https://github.com/ocaml/dune/releases/download/3.16.0/dune-3.16.0.tbz",
+         "sha256": "5481dde7918ca3121e02c34d74339f734b32d5883efb8c1b8056471e74f9bda6"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "yojson": {
+       "version": "2.2.2",
+       "src": {
+         "url": "https://github.com/ocaml-community/yojson/releases/download/2.2.2/yojson-2.2.2.tbz",
+         "sha256": "9abfad8c9a79d4723ad2f6448e669c1e68dbfc87cc54a1b7c064b0c90912c595"
+       },
+       "depends": [
+         "dune",
+         "ocaml",
+         "seq"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "zarith": {
+       "version": "1.14",
+       "src": {
+         "url": "https://github.com/ocaml/Zarith/archive/release-1.14.tar.gz",
+         "sha256": "5db9dcbd939153942a08581fabd846d0f3f2b8c67fe68b855127e0472d4d1859"
+       },
+       "depends": [
+         "conf-gmp",
+         "conf-pkg-config",
+         "ocaml",
+         "ocamlfind"
+       ],
+       "build-depends": [
+         "ocamlfind"
+       ]
+     },
+     "zed": {
+       "version": "3.2.3",
+       "src": {
+         "url": "https://github.com/ocaml-community/zed/archive/refs/tags/3.2.3.tar.gz",
+         "sha512": "637f75129550f6459417549d44bed16bdc62721d2e9e0c6bb5bfab30c5bc6478de15faece8c091b56f238375cb79a7bc176375400e543120bb31d7ea626b7c5b"
+       },
+       "depends": [
+         "dune",
+         "ocaml",
+         "react",
+         "result",
+         "uchar",
+         "uucp",
+         "uuseg",
+         "uutf"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     }
+   }
+}

--- a/onix-lock.json
+++ b/onix-lock.json
@@ -1,0 +1,1462 @@
+{
+   "version": "0.0.5",
+   "repositories": [
+     {
+       "url": "https://github.com/ocaml/opam-repository.git",
+       "rev": "ce4637ae20e511e8dc54562b123f1407fa5b2ca8"
+     }
+   ],
+   "packages" : {
+     "angstrom": {
+       "version": "0.16.1",
+       "src": {
+         "url": "https://github.com/inhabitedtype/angstrom/archive/0.16.1.tar.gz",
+         "sha256": "143536fb4d049574c539b9990840615e078ed3dd94e1d24888293f68349a100b"
+       },
+       "depends": [
+         "bigstringaf",
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune",
+         "ocaml-syntax-shims"
+       ]
+     },
+     "asn1-combinators": {
+       "version": "0.2.6",
+       "src": {
+         "url": "https://github.com/mirleft/ocaml-asn1-combinators/releases/download/v0.2.6/asn1-combinators-v0.2.6.tbz",
+         "sha256": "012ade0d8869ef621063752c1cf8ea026f6bc702fed10df9af56688e291b1a91"
+       },
+       "depends": [
+         "cstruct",
+         "dune",
+         "ocaml",
+         "ptime",
+         "zarith"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "astring": {
+       "version": "0.8.5",
+       "src": {
+         "url": "https://erratique.ch/software/astring/releases/astring-0.8.5.tbz",
+         "sha256": "865692630c07c3ab87c66cdfc2734c0fdfc9c34a57f8e89ffec7c7d15e7a70fa"
+       },
+       "depends": [
+         "ocaml"
+       ],
+       "build-depends": [
+         "ocamlbuild",
+         "ocamlfind",
+         "topkg"
+       ]
+     },
+     "base": {
+       "version": "v0.17.1",
+       "src": {
+         "url": "https://github.com/janestreet/base/archive/refs/tags/v0.17.1.tar.gz",
+         "sha512": "ed5eb5e83d8085fc06f111862d609b393e394bbdcc6e25bab50030a250ffa2e540dbee02169b6f28ec220f10f61d189cd7b5646eece910c63620f5174fb5a655"
+       },
+       "depends": [
+         "dune",
+         "dune-configurator",
+         "ocaml",
+         "ocaml_intrinsics_kernel",
+         "sexplib0"
+       ],
+       "build-depends": [
+         "dune",
+         "dune-configurator"
+       ]
+     },
+     "base-bigarray": {
+       "version": "base"
+     },
+     "base-bytes": {
+       "version": "base",
+       "depends": [
+         "ocaml",
+         "ocamlfind"
+       ],
+       "build-depends": [
+         "ocamlfind"
+       ]
+     },
+     "base-domains": {
+       "version": "base",
+       "depends": [
+         "ocaml"
+       ]
+     },
+     "base-nnp": {
+       "version": "base",
+       "depends": [
+         "base-domains"
+       ]
+     },
+     "base-threads": {
+       "version": "base"
+     },
+     "base-unix": {
+       "version": "base"
+     },
+     "base64": {
+       "version": "3.5.1",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-base64/releases/download/v3.5.1/base64-3.5.1.tbz",
+         "sha256": "d8fedaa59bd12feae7acc08b5928dd478aac523f4ca8d240470d2500651c65ed"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "bigstringaf": {
+       "version": "0.10.0",
+       "src": {
+         "url": "https://github.com/inhabitedtype/bigstringaf/archive/0.10.0.tar.gz",
+         "sha256": "0a4zfb1plzvcq42rfkxfm4bkg3q6n5clswzczkgbj4dwbyqgb4pd"
+       },
+       "depends": [
+         "dune",
+         "dune-configurator",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune",
+         "dune-configurator"
+       ]
+     },
+     "bos": {
+       "version": "0.2.1",
+       "src": {
+         "url": "https://erratique.ch/software/bos/releases/bos-0.2.1.tbz",
+         "sha512": "8daeb8a4c2dd1f2460f6274ada19f4f1b6ebe875ff83a938c93418ce0e6bdb74b8afc5c9a7d410c1c9df2dad030e4fa276b6ed2da580639484e8b5bc92610b1d"
+       },
+       "depends": [
+         "astring",
+         "base-unix",
+         "fmt",
+         "fpath",
+         "logs",
+         "ocaml",
+         "rresult"
+       ],
+       "build-depends": [
+         "ocamlbuild",
+         "ocamlfind",
+         "topkg"
+       ]
+     },
+     "ca-certs": {
+       "version": "0.2.3",
+       "src": {
+         "url": "https://github.com/mirage/ca-certs/releases/download/v0.2.3/ca-certs-0.2.3.tbz",
+         "sha256": "d2d8d6457d915ef6d783def82f3be5ec2f56f92e20214f58edd63c9c2fc60e9c"
+       },
+       "depends": [
+         "astring",
+         "bos",
+         "dune",
+         "fpath",
+         "logs",
+         "mirage-crypto",
+         "ocaml",
+         "ptime",
+         "x509"
+       ],
+       "build-depends": [
+         "dune"
+       ],
+       "depexts": [
+         "ca_root_nss"
+       ]
+     },
+     "camlzip": {
+       "version": "1.13",
+       "src": {
+         "url": "https://github.com/xavierleroy/camlzip/archive/rel113.tar.gz",
+         "sha256": "8a038692ac811cdd2fdff9b37b5892b7a912c2042641187eae29757d98565d9e"
+       },
+       "depends": [
+         "conf-zlib",
+         "ocaml"
+       ],
+       "build-depends": [
+         "ocamlfind"
+       ]
+     },
+     "cmdliner": {
+       "version": "1.3.0",
+       "src": {
+         "url": "https://erratique.ch/software/cmdliner/releases/cmdliner-1.3.0.tbz",
+         "sha512": "4c46bc334444ff772637deae2f5ba03645d7a1b7db523470a1246acfce79b971c764d964cbb02388639b3161b279700d9ade95da550446fb32aa4849c8a8f283"
+       },
+       "depends": [
+         "ocaml"
+       ]
+     },
+     "cohttp": {
+       "version": "5.3.1",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-cohttp/releases/download/v5.3.1/cohttp-5.3.1.tbz",
+         "sha256": "f5e273d3c2f29ff47bd7e16db23e1f3d6cd01a40be00208985bc434c88d4576b"
+       },
+       "depends": [
+         "base-bytes",
+         "base64",
+         "dune",
+         "ocaml",
+         "ppx_sexp_conv",
+         "re",
+         "sexplib0",
+         "stringext",
+         "uri",
+         "uri-sexp"
+       ],
+       "build-depends": [
+         "dune",
+         "jsonm"
+       ]
+     },
+     "cohttp-lwt": {
+       "version": "5.3.0",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-cohttp/releases/download/v5.3.0/cohttp-5.3.0.tbz",
+         "sha256": "b3bd91c704e5ea510e924b83ab2ede1fc46a2cce448b0f8cef4883b9a16eeddd"
+       },
+       "depends": [
+         "cohttp",
+         "dune",
+         "logs",
+         "lwt",
+         "ocaml",
+         "ppx_sexp_conv",
+         "sexplib0",
+         "uri"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "cohttp-lwt-unix": {
+       "version": "5.3.0",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-cohttp/releases/download/v5.3.0/cohttp-5.3.0.tbz",
+         "sha256": "b3bd91c704e5ea510e924b83ab2ede1fc46a2cce448b0f8cef4883b9a16eeddd"
+       },
+       "depends": [
+         "base-unix",
+         "cmdliner",
+         "cohttp-lwt",
+         "conduit-lwt",
+         "conduit-lwt-unix",
+         "dune",
+         "fmt",
+         "logs",
+         "lwt",
+         "magic-mime",
+         "ocaml",
+         "ppx_sexp_conv"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "conduit": {
+       "version": "6.2.3",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-conduit/releases/download/v6.2.3/conduit-6.2.3.tbz",
+         "sha256": "3a4684bb1485b1f247d6084dd0a356e1027e92c2cd467b35cabd59a764423e79"
+       },
+       "depends": [
+         "astring",
+         "dune",
+         "ipaddr",
+         "ipaddr-sexp",
+         "logs",
+         "ocaml",
+         "ppx_sexp_conv",
+         "sexplib",
+         "uri"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "conduit-lwt": {
+       "version": "6.2.3",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-conduit/releases/download/v6.2.3/conduit-6.2.3.tbz",
+         "sha256": "3a4684bb1485b1f247d6084dd0a356e1027e92c2cd467b35cabd59a764423e79"
+       },
+       "depends": [
+         "base-unix",
+         "conduit",
+         "dune",
+         "lwt",
+         "ocaml",
+         "ppx_sexp_conv",
+         "sexplib"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "conduit-lwt-unix": {
+       "version": "6.2.3",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-conduit/releases/download/v6.2.3/conduit-6.2.3.tbz",
+         "sha256": "3a4684bb1485b1f247d6084dd0a356e1027e92c2cd467b35cabd59a764423e79"
+       },
+       "depends": [
+         "base-unix",
+         "ca-certs",
+         "conduit-lwt",
+         "dune",
+         "ipaddr",
+         "ipaddr-sexp",
+         "logs",
+         "lwt",
+         "ocaml",
+         "ppx_sexp_conv",
+         "tls-lwt",
+         "uri"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "conf-gmp": {
+       "version": "4",
+       "src-extra": {
+         "test.c": {
+           "url": "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/conf-gmp/test.c.4",
+           "sha256": "54a30735f1f271a2531526747e75716f4490dd7bc1546efd6498ccfe3cc4d6fb"
+         }
+       },
+       "depexts": [
+         "gmp"
+       ]
+     },
+     "conf-gmp-powm-sec": {
+       "version": "3",
+       "src-extra": {
+         "test.c": {
+           "url": "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/conf-gmp-powm-sec/test.c.3",
+           "sha256": "388b3879530257a7e6e59b68208ee2a52de7be30e40eb4d3a54419708fdad490"
+         }
+       },
+       "depends": [
+         "conf-gmp"
+       ]
+     },
+     "conf-pkg-config": {
+       "version": "3",
+       "depexts": [
+         "pkg-config"
+       ]
+     },
+     "conf-zlib": {
+       "version": "1",
+       "build-depends": [
+         "conf-pkg-config"
+       ],
+       "depexts": [
+         "zlib"
+       ]
+     },
+     "containers": {
+       "version": "3.14",
+       "src": {
+         "url": "https://github.com/c-cube/ocaml-containers/releases/download/v3.14/containers-3.14.tbz",
+         "sha256": "c94fba0c7c54349b7021c31f85120495197ddde438c574d48362ec669bf7e564"
+       },
+       "depends": [
+         "base-threads",
+         "base-unix",
+         "dune",
+         "dune-configurator",
+         "either",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune",
+         "dune-configurator"
+       ]
+     },
+     "cppo": {
+       "version": "1.7.0",
+       "src": {
+         "url": "https://github.com/ocaml-community/cppo/archive/refs/tags/v1.7.0.tar.gz",
+         "sha512": "cafa2f7add42912b413f39e1d9fb7a2a42a9be134128c179dfe353f35a6c32840720d2166a77d985941300cb945b9c424b38401d20027d814b25f3bac534506d"
+       },
+       "depends": [
+         "base-unix",
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "csexp": {
+       "version": "1.5.2",
+       "src": {
+         "url": "https://github.com/ocaml-dune/csexp/releases/download/1.5.2/csexp-1.5.2.tbz",
+         "sha256": "1a14dd04bb4379a41990248550628c77913a9c07f3c35c1370b6960e697787ff"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "cstruct": {
+       "version": "6.2.0",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-cstruct/releases/download/v6.2.0/cstruct-6.2.0.tbz",
+         "sha256": "9a78073392580e8349148fa3ab4b1b2e989dc9d30d07401b04c96b7c60f03e62"
+       },
+       "depends": [
+         "dune",
+         "fmt",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "domain-name": {
+       "version": "0.4.0",
+       "src": {
+         "url": "https://github.com/hannesm/domain-name/releases/download/v0.4.0/domain-name-0.4.0.tbz",
+         "sha256": "a5c06e22845895201973e812fe3019274d1db81c0a7873da6c8007c4ad2108c5"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "dune": {
+       "version": "3.16.0",
+       "src": {
+         "url": "https://github.com/ocaml/dune/releases/download/3.16.0/dune-3.16.0.tbz",
+         "sha256": "5481dde7918ca3121e02c34d74339f734b32d5883efb8c1b8056471e74f9bda6"
+       },
+       "depends": [
+         "base-threads",
+         "base-unix",
+         "ocaml"
+       ]
+     },
+     "dune-configurator": {
+       "version": "3.16.0",
+       "src": {
+         "url": "https://github.com/ocaml/dune/releases/download/3.16.0/dune-3.16.0.tbz",
+         "sha256": "5481dde7918ca3121e02c34d74339f734b32d5883efb8c1b8056471e74f9bda6"
+       },
+       "depends": [
+         "base-unix",
+         "csexp",
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "duration": {
+       "version": "0.2.1",
+       "src": {
+         "url": "https://github.com/hannesm/duration/releases/download/v0.2.1/duration-0.2.1.tbz",
+         "sha256": "c738c1f38cfb99820c121cd3ddf819de4b2228f0d50eacbd1cc3ce99e7c71e2b"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "either": {
+       "version": "1.0.0",
+       "src": {
+         "url": "https://github.com/mirage/either/releases/download/1.0.0/either-1.0.0.tbz",
+         "sha256": "bf674de3312dee7b7215f07df1e8a96eb3d679164b8a918cdd95b8d97e505884"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "eqaf": {
+       "version": "0.9",
+       "src": {
+         "url": "https://github.com/mirage/eqaf/releases/download/v0.9/eqaf-0.9.tbz",
+         "sha256": "ec0e28a946ac6817f95d5854f05a9961ae3a8408bb610e79cfad01b9b255dfe0"
+       },
+       "depends": [
+         "cstruct",
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ezgzip": {
+       "version": "0.2.3",
+       "src": {
+         "url": "https://github.com/hcarty/ezgzip/releases/download/v0.2.3/ezgzip-v0.2.3.tbz",
+         "sha256": "8868eedb98f83b2d53f091a827db9b7a5b4e9ba538bbc080c91b4ac4baf679d4"
+       },
+       "depends": [
+         "astring",
+         "camlzip",
+         "dune",
+         "ocaml",
+         "ocplib-endian",
+         "rresult"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "fmt": {
+       "version": "0.9.0",
+       "src": {
+         "url": "https://erratique.ch/software/fmt/releases/fmt-0.9.0.tbz",
+         "sha512": "66cf4b8bb92232a091dfda5e94d1c178486a358cdc34b1eec516d48ea5acb6209c0dfcb416f0c516c50ddbddb3c94549a45e4a6d5c5fd1c81d3374dec823a83b"
+       },
+       "depends": [
+         "base-unix",
+         "cmdliner",
+         "ocaml"
+       ],
+       "build-depends": [
+         "ocamlbuild",
+         "ocamlfind",
+         "topkg"
+       ]
+     },
+     "fpath": {
+       "version": "0.7.3",
+       "src": {
+         "url": "https://erratique.ch/software/fpath/releases/fpath-0.7.3.tbz",
+         "sha256": "12b08ff192d037d9b6d69e9ca19d1d385184f20b3237c27231e437ac81ace70f"
+       },
+       "depends": [
+         "astring",
+         "ocaml"
+       ],
+       "build-depends": [
+         "ocamlbuild",
+         "ocamlfind",
+         "topkg"
+       ]
+     },
+     "gcloud": {
+       "version": "dev",
+       "src": { "url": "file://." },
+       "depends": [
+         "base64",
+         "cohttp",
+         "cohttp-lwt-unix",
+         "containers",
+         "cstruct",
+         "dune",
+         "ezgzip",
+         "jose",
+         "logs",
+         "lwt",
+         "ppx_deriving_yojson",
+         "x509",
+         "yojson"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "gcloud-cli": {
+       "version": "dev",
+       "src": { "url": "file://." },
+       "depends": [
+         "cmdliner",
+         "cohttp",
+         "dune",
+         "gcloud",
+         "logs",
+         "tls-lwt"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "gmap": {
+       "version": "0.3.0",
+       "src": {
+         "url": "https://github.com/hannesm/gmap/releases/download/0.3.0/gmap-0.3.0.tbz",
+         "sha256": "04dd9e6226ac8f8fb4ccb6021048702e34a482fb9c1d240d3852829529507c1c"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "hkdf": {
+       "version": "1.0.4",
+       "src": {
+         "url": "https://github.com/hannesm/ocaml-hkdf/releases/download/v1.0.4/hkdf-v1.0.4.tbz",
+         "sha256": "b926d6da4ac45aab999735dd2bbfd1f7511316710d791afa361006b6fe36fd5b"
+       },
+       "depends": [
+         "cstruct",
+         "dune",
+         "mirage-crypto",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "host-arch-unknown": {
+       "version": "1"
+     },
+     "ipaddr": {
+       "version": "5.6.0",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.6.0/ipaddr-5.6.0.tbz",
+         "sha256": "9e30433fdb4ca437a6aa8ffb447baca5eba7615fb88e7b0cd8a4b416c3208133"
+       },
+       "depends": [
+         "domain-name",
+         "dune",
+         "macaddr",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ipaddr-sexp": {
+       "version": "5.6.0",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.6.0/ipaddr-5.6.0.tbz",
+         "sha256": "9e30433fdb4ca437a6aa8ffb447baca5eba7615fb88e7b0cd8a4b416c3208133"
+       },
+       "depends": [
+         "dune",
+         "ipaddr",
+         "ocaml",
+         "ppx_sexp_conv",
+         "sexplib0"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "jose": {
+       "version": "0.9.0",
+       "src": {
+         "url": "https://github.com/ulrikstrid/reason-jose/releases/download/v0.9.0/jose-v0.9.0.tbz",
+         "sha256": "c449a63c53043deb149cfc1305e578971bb5b460f17b4a66e286e826f2dbc18d"
+       },
+       "depends": [
+         "astring",
+         "base64",
+         "cstruct",
+         "dune",
+         "eqaf",
+         "mirage-crypto",
+         "ocaml",
+         "ptime",
+         "x509",
+         "yojson",
+         "zarith"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "jsonm": {
+       "version": "1.0.2",
+       "src": {
+         "url": "https://erratique.ch/software/jsonm/releases/jsonm-1.0.2.tbz",
+         "sha512": "0072f5c31080202ed1cb996a8530d72c882723f26b597f784441033f59338ba8c0cbabf901794d5b1ae749a54af4d7ebf7b47987db43488c7f6ac7fe191a042f"
+       },
+       "depends": [
+         "ocaml",
+         "uutf"
+       ],
+       "build-depends": [
+         "ocamlbuild",
+         "ocamlfind",
+         "topkg"
+       ]
+     },
+     "logs": {
+       "version": "0.7.0",
+       "src": {
+         "url": "https://erratique.ch/software/logs/releases/logs-0.7.0.tbz",
+         "sha256": "86f4a02807eb1a297aae44977d9f61e419c31458a5d7b23c6f55575e8e69d5ca"
+       },
+       "depends": [
+         "base-threads",
+         "cmdliner",
+         "fmt",
+         "lwt",
+         "ocaml"
+       ],
+       "build-depends": [
+         "ocamlbuild",
+         "ocamlfind",
+         "topkg"
+       ]
+     },
+     "lwt": {
+       "version": "5.8.0",
+       "src": {
+         "url": "https://github.com/ocsigen/lwt/archive/refs/tags/5.8.0.tar.gz",
+         "sha512": "7f6548a1b1dbfdbc98d9352151ca7be97fa2ab63dbcc429208ce8d08308eee13f7fce31e0cca53f8880233959a60212d622270dd51bf164c3ee272f179769bd9"
+       },
+       "depends": [
+         "base-threads",
+         "base-unix",
+         "dune",
+         "dune-configurator",
+         "ocaml",
+         "ocplib-endian"
+       ],
+       "build-depends": [
+         "cppo",
+         "dune",
+         "dune-configurator"
+       ]
+     },
+     "macaddr": {
+       "version": "5.6.0",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.6.0/ipaddr-5.6.0.tbz",
+         "sha256": "9e30433fdb4ca437a6aa8ffb447baca5eba7615fb88e7b0cd8a4b416c3208133"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "magic-mime": {
+       "version": "1.3.1",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-magic-mime/releases/download/v1.3.1/magic-mime-1.3.1.tbz",
+         "sha256": "e0234d03625dba1efac58e57e387672d75a5e9a621ff49acfe0f609c00f13b08"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "mirage-crypto": {
+       "version": "0.11.3",
+       "src": {
+         "url": "https://github.com/mirage/mirage-crypto/releases/download/v0.11.3/mirage-crypto-0.11.3.tbz",
+         "sha256": "bfb530fa169cd905ebc7e2449f3407cfbd67023ac0b291b8b6f4a1437a5d95b1"
+       },
+       "depends": [
+         "cstruct",
+         "dune",
+         "dune-configurator",
+         "eqaf",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune",
+         "dune-configurator"
+       ]
+     },
+     "mirage-crypto-ec": {
+       "version": "0.11.3",
+       "src": {
+         "url": "https://github.com/mirage/mirage-crypto/releases/download/v0.11.3/mirage-crypto-0.11.3.tbz",
+         "sha256": "bfb530fa169cd905ebc7e2449f3407cfbd67023ac0b291b8b6f4a1437a5d95b1"
+       },
+       "depends": [
+         "cstruct",
+         "dune",
+         "dune-configurator",
+         "eqaf",
+         "mirage-crypto",
+         "mirage-crypto-rng",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune",
+         "dune-configurator"
+       ]
+     },
+     "mirage-crypto-pk": {
+       "version": "0.11.3",
+       "src": {
+         "url": "https://github.com/mirage/mirage-crypto/releases/download/v0.11.3/mirage-crypto-0.11.3.tbz",
+         "sha256": "bfb530fa169cd905ebc7e2449f3407cfbd67023ac0b291b8b6f4a1437a5d95b1"
+       },
+       "depends": [
+         "cstruct",
+         "dune",
+         "eqaf",
+         "mirage-crypto",
+         "mirage-crypto-rng",
+         "ocaml",
+         "sexplib0",
+         "zarith"
+       ],
+       "build-depends": [
+         "conf-gmp-powm-sec",
+         "dune"
+       ]
+     },
+     "mirage-crypto-rng": {
+       "version": "0.11.3",
+       "src": {
+         "url": "https://github.com/mirage/mirage-crypto/releases/download/v0.11.3/mirage-crypto-0.11.3.tbz",
+         "sha256": "bfb530fa169cd905ebc7e2449f3407cfbd67023ac0b291b8b6f4a1437a5d95b1"
+       },
+       "depends": [
+         "cstruct",
+         "dune",
+         "dune-configurator",
+         "duration",
+         "logs",
+         "mirage-crypto",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune",
+         "dune-configurator"
+       ]
+     },
+     "mirage-crypto-rng-lwt": {
+       "version": "0.11.3",
+       "src": {
+         "url": "https://github.com/mirage/mirage-crypto/releases/download/v0.11.3/mirage-crypto-0.11.3.tbz",
+         "sha256": "bfb530fa169cd905ebc7e2449f3407cfbd67023ac0b291b8b6f4a1437a5d95b1"
+       },
+       "depends": [
+         "dune",
+         "duration",
+         "logs",
+         "lwt",
+         "mirage-crypto",
+         "mirage-crypto-rng",
+         "mtime",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "mtime": {
+       "version": "2.1.0",
+       "src": {
+         "url": "https://erratique.ch/software/mtime/releases/mtime-2.1.0.tbz",
+         "sha512": "a6619f1a3f1a5b32b7a9a067b939f94e6c66244eb90762d41f2cb1c9af852dd7d270fedb20e2b9b61875d52ba46e24af6ebf5950d1284b0b75b2fd2c380d9af3"
+       },
+       "depends": [
+         "ocaml"
+       ],
+       "build-depends": [
+         "ocamlbuild",
+         "ocamlfind",
+         "topkg"
+       ]
+     },
+     "num": {
+       "version": "1.5-1",
+       "src": {
+         "url": "https://github.com/ocaml/num/archive/v1.5.tar.gz",
+         "sha512": "110dd01140c1c96f5f067aa824bb63f74a26411dcaa65aaf04cb6c44b116ca02aaab9505f431c66964388ce4a31d86da5928b4c0e5557800e834de80bed46495"
+       },
+       "src-extra": {
+         "num-in-findlib-dir.patch": {
+           "url": "https://github.com/ocaml/num/commit/f6e31b1653f32c7c425b69c2b123ab2f924a4d61.patch?full_index=1",
+           "sha256": "f93880031ed823249f4aac860e0d9e5cdc2878550db13914db25b1585803cf05"
+         }
+       },
+       "depends": [
+         "ocaml"
+       ]
+     },
+     "ocaml": {
+       "version": "5.2.0",
+       "depends": [
+         "ocaml-config",
+         "ocaml-system"
+       ],
+       "build-depends": [
+         "ocaml-system"
+       ]
+     },
+     "ocaml-compiler-libs": {
+       "version": "v0.17.0",
+       "src": {
+         "url": "https://github.com/janestreet/ocaml-compiler-libs/archive/refs/tags/v0.17.0.tar.gz",
+         "sha512": "c5cd418b0eb74e00c3f63235754bbdb3a3328ac743d6ae885424d8c50b4edaa7068572e689cb3456d222793283927f2984a1ff840b1bc3817f810b5314faf897"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ocaml-config": {
+       "version": "3",
+       "src-extra": {
+         "gen_ocaml_config.ml.in": {
+           "url": "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-config/gen_ocaml_config.ml.in.3",
+           "sha256": "a9ad8d84a08961159653a978db92d10f694510182b206cacb96d5c9f63b5121e"
+         },
+         "ocaml-config.install": {
+           "url": "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-config/ocaml-config.install",
+           "sha256": "6e4fd93f4cce6bad0ed3c08afd0248dbe7d7817109281de6294e5b5ef5597051"
+         }
+       },
+       "depends": [
+         "ocaml-system"
+       ],
+       "build-depends": [
+         "ocaml-system"
+       ]
+     },
+     "ocaml-syntax-shims": {
+       "version": "1.0.0",
+       "src": {
+         "url": "https://github.com/ocaml-ppx/ocaml-syntax-shims/releases/download/1.0.0/ocaml-syntax-shims-1.0.0.tbz",
+         "sha256": "89b2e193e90a0c168b6ec5ddf6fef09033681bdcb64e11913c97440a2722e8c8"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ocaml-system": {
+       "version": "5.2.0",
+       "src-extra": {
+         "gen_ocaml_config.ml.in": {
+           "url": "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-system/gen_ocaml_config.ml.in",
+           "sha256": "71bcd3d35e28cbf71eda81991c8741268f4b87ced71573b2e75f64f136cebfc1"
+         }
+       },
+       "depends": [
+         "host-arch-unknown"
+       ],
+       "depexts": [
+         "ocaml-ng.ocamlPackages_5_2.ocaml"
+       ]
+     },
+     "ocaml_intrinsics_kernel": {
+       "version": "v0.17.1",
+       "src": {
+         "url": "https://github.com/janestreet/ocaml_intrinsics_kernel/archive/refs/tags/v0.17.1.tar.gz",
+         "sha512": "21e596d6407a620866cee7cab47ef1a9446d6a733b4994e809ea5566d5fa956682a5c6a6190ffb0ed48458abd658301944ed10c4389d91ecb8df677a5f87f2ab"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ocamlbuild": {
+       "version": "0.15.0",
+       "src": {
+         "url": "https://github.com/ocaml/ocamlbuild/archive/refs/tags/0.15.0.tar.gz",
+         "sha512": "c8311a9a78491bf759eb27153d6ba4692d27cd935759a145f96a8ba8f3c2e97cef54e7d654ed1c2c07c74f60482a4fef5224e26d0f04450e69cdcb9418c762d3"
+       },
+       "depends": [
+         "ocaml"
+       ]
+     },
+     "ocamlfind": {
+       "version": "1.9.6",
+       "src": {
+         "url": "http://download.camlcity.org/download/findlib-1.9.6.tar.gz",
+         "sha512": "cfaf1872d6ccda548f07d32cc6b90c3aafe136d2aa6539e03143702171ee0199add55269bba894c77115535dc46a5835901a5d7c75768999e72db503bfd83027"
+       },
+       "src-extra": {
+         "0001-Harden-test-for-OCaml-5.patch": {
+           "url": "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocamlfind/0001-Harden-test-for-OCaml-5.patch",
+           "sha256": "6fcca5f2f7abf8d6304da6c385348584013ffb8602722a87fb0bacbab5867fe8"
+         }
+       },
+       "depends": [
+         "ocaml"
+       ]
+     },
+     "ocplib-endian": {
+       "version": "1.2",
+       "src": {
+         "url": "https://github.com/OCamlPro/ocplib-endian/archive/refs/tags/1.2.tar.gz",
+         "sha512": "2e70be5f3d6e377485c60664a0e235c3b9b24a8d6b6a03895d092c6e40d53810bfe1f292ee69e5181ce6daa8a582bfe3d59f3af889f417134f658812be5b8b85"
+       },
+       "depends": [
+         "base-bytes",
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "cppo",
+         "dune"
+       ]
+     },
+     "parsexp": {
+       "version": "v0.17.0",
+       "src": {
+         "url": "https://github.com/janestreet/parsexp/archive/refs/tags/v0.17.0.tar.gz",
+         "sha256": "a3d10edbc4f98d16357b644d550fd1c06f4d9aa4990ab8ee6da01276c24d55b5"
+       },
+       "depends": [
+         "dune",
+         "ocaml",
+         "sexplib0"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "pbkdf": {
+       "version": "1.2.0",
+       "src": {
+         "url": "https://github.com/abeaumont/ocaml-pbkdf/archive/1.2.0.tar.gz",
+         "sha512": "d6f7d5efd761b87dd420ddcf97c2f9d4402dcc81d65cd1f4d81039b70c4d8c1e803bbaf4251482de8de7076da9f40b48c7eb1684e31e7a316deb5036c192bd3c"
+       },
+       "depends": [
+         "cstruct",
+         "dune",
+         "mirage-crypto",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ppx_derivers": {
+       "version": "1.2.1",
+       "src": {
+         "url": "https://github.com/ocaml-ppx/ppx_derivers/archive/1.2.1.tar.gz",
+         "sha256": "b6595ee187dea792b31fc54a0e1524ab1e48bc6068d3066c45215a138cc73b95"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ppx_deriving": {
+       "version": "6.0.3",
+       "src": {
+         "url": "https://github.com/ocaml-ppx/ppx_deriving/releases/download/v6.0.3/ppx_deriving-6.0.3.tbz",
+         "sha256": "374aa97b32c5e01c09a97810a48bfa218c213b5b649e4452101455ac19c94a6d"
+       },
+       "depends": [
+         "dune",
+         "ocaml",
+         "ocamlfind",
+         "ppx_derivers",
+         "ppxlib"
+       ],
+       "build-depends": [
+         "cppo",
+         "dune",
+         "ocamlfind"
+       ]
+     },
+     "ppx_deriving_yojson": {
+       "version": "3.9.0",
+       "src": {
+         "url": "https://github.com/ocaml-ppx/ppx_deriving_yojson/releases/download/v3.9.0/ppx_deriving_yojson-3.9.0.tbz",
+         "sha256": "6745f4f6615c918b0b00296161e0da20c1a6b2b8650bf1b7a5313f94171c4047"
+       },
+       "depends": [
+         "dune",
+         "ocaml",
+         "ppx_deriving",
+         "ppxlib",
+         "yojson"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ppx_sexp_conv": {
+       "version": "v0.17.0",
+       "src": {
+         "url": "https://github.com/janestreet/ppx_sexp_conv/archive/refs/tags/v0.17.0.tar.gz",
+         "sha256": "4af4f99d774fab77bf63ba2298fc288c356a88bdac0a37e3a23b0d669410ee5a"
+       },
+       "depends": [
+         "base",
+         "dune",
+         "ocaml",
+         "ppxlib",
+         "ppxlib_jane",
+         "sexplib0"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ppxlib": {
+       "version": "0.33.1~5.3preview",
+       "src": {
+         "url": "https://github.com/ocaml-ppx/ppxlib/archive/ac7fcfc88d574609b62cc0a38e0de59d03cc96de.tar.gz",
+         "sha256": "d679f110b92ed12156556ee1d3779d11cef605c36f0bc417943e7996f0d2bbaf"
+       },
+       "depends": [
+         "dune",
+         "ocaml",
+         "ocaml-compiler-libs",
+         "ppx_derivers",
+         "sexplib0",
+         "stdlib-shims"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ppxlib_jane": {
+       "version": "v0.17.0",
+       "src": {
+         "url": "https://github.com/janestreet/ppxlib_jane/archive/refs/tags/v0.17.0.tar.gz",
+         "sha256": "42757d7b44a5f2a766778e6b4710100c6ef9d0c074eb3e7fa4c69647336d8398"
+       },
+       "depends": [
+         "dune",
+         "ocaml",
+         "ppxlib"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "ptime": {
+       "version": "1.2.0",
+       "src": {
+         "url": "https://erratique.ch/software/ptime/releases/ptime-1.2.0.tbz",
+         "sha512": "b0c3240dd9e777a5e60b5269eb2e312fc644d29ef55e257d2f2538c03bf62274173ed36e13858c44d2dbee8fe375c9c483e705706e4aa5b3b5c4609ca6324a5c"
+       },
+       "depends": [
+         "ocaml"
+       ],
+       "build-depends": [
+         "ocamlbuild",
+         "ocamlfind",
+         "topkg"
+       ]
+     },
+     "re": {
+       "version": "1.12.0",
+       "src": {
+         "url": "https://github.com/ocaml/ocaml-re/releases/download/1.12.0/re-1.12.0.tbz",
+         "sha256": "a01f2bf22f72c2f4ababd8d3e7635e35c1bf6bc5a41ad6d5a007454ddabad1d4"
+       },
+       "depends": [
+         "dune",
+         "ocaml",
+         "seq"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "rresult": {
+       "version": "0.7.0",
+       "src": {
+         "url": "https://erratique.ch/software/rresult/releases/rresult-0.7.0.tbz",
+         "sha512": "f1bb631c986996388e9686d49d5ae4d8aaf14034f6865c62a88fb58c48ce19ad2eb785327d69ca27c032f835984e0bd2efd969b415438628a31f3e84ec4551d3"
+       },
+       "depends": [
+         "ocaml"
+       ],
+       "build-depends": [
+         "ocamlbuild",
+         "ocamlfind",
+         "topkg"
+       ]
+     },
+     "seq": {
+       "version": "base",
+       "src-extra": {
+         "META.seq": {
+           "url": "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/seq/META.seq",
+           "sha256": "e95062b4d0519ef8335c02f7d0f1952d11b814c7ab7e6d566a206116162fa2be"
+         },
+         "seq.install": {
+           "url": "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/seq/seq.install",
+           "sha256": "fff926c2c4d5a82b6c94c60c4c35eb06e3d39975893ebe6b1f0e6557cbe34904"
+         }
+       },
+       "depends": [
+         "ocaml"
+       ]
+     },
+     "sexplib": {
+       "version": "v0.17.0",
+       "src": {
+         "url": "https://github.com/janestreet/sexplib/archive/refs/tags/v0.17.0.tar.gz",
+         "sha256": "da863b42b81235fdcf45eb32c04fb8bde22ff446a779cfb6f989730a35103160"
+       },
+       "depends": [
+         "dune",
+         "num",
+         "ocaml",
+         "parsexp",
+         "sexplib0"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "sexplib0": {
+       "version": "v0.17.0",
+       "src": {
+         "url": "https://github.com/janestreet/sexplib0/archive/refs/tags/v0.17.0.tar.gz",
+         "sha512": "ad387e40789fe70a11473db7e85fe017b801592624414e9030730b2e92ea08f98095fb6e9236430f33c801605ebee0a2a6284e0f618a26a7da4599d4fd9d395d"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "stdlib-shims": {
+       "version": "0.3.0",
+       "src": {
+         "url": "https://github.com/ocaml/stdlib-shims/releases/download/0.3.0/stdlib-shims-0.3.0.tbz",
+         "sha256": "babf72d3917b86f707885f0c5528e36c63fccb698f4b46cf2bab5c7ccdd6d84a"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "stringext": {
+       "version": "1.6.0",
+       "src": {
+         "url": "https://github.com/rgrinberg/stringext/releases/download/1.6.0/stringext-1.6.0.tbz",
+         "sha256": "db41f5d52e9eab17615f110b899dfeb27dd7e7f89cd35ae43827c5119db206ea"
+       },
+       "depends": [
+         "dune",
+         "ocaml"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "tls": {
+       "version": "0.17.5",
+       "src": {
+         "url": "https://github.com/mirleft/ocaml-tls/releases/download/v0.17.5/tls-0.17.5.tbz",
+         "sha256": "89108857bf3a6f85722925a8d4a3f59c291d638c0f2e2fc45f0fdaf892ae4819"
+       },
+       "depends": [
+         "cstruct",
+         "domain-name",
+         "dune",
+         "fmt",
+         "hkdf",
+         "ipaddr",
+         "logs",
+         "mirage-crypto",
+         "mirage-crypto-ec",
+         "mirage-crypto-pk",
+         "mirage-crypto-rng",
+         "ocaml",
+         "x509"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "tls-lwt": {
+       "version": "0.17.5",
+       "src": {
+         "url": "https://github.com/mirleft/ocaml-tls/releases/download/v0.17.5/tls-0.17.5.tbz",
+         "sha256": "89108857bf3a6f85722925a8d4a3f59c291d638c0f2e2fc45f0fdaf892ae4819"
+       },
+       "depends": [
+         "cmdliner",
+         "dune",
+         "lwt",
+         "mirage-crypto-rng-lwt",
+         "ocaml",
+         "ptime",
+         "tls",
+         "x509"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "topkg": {
+       "version": "1.0.7",
+       "src": {
+         "url": "https://erratique.ch/software/topkg/releases/topkg-1.0.7.tbz",
+         "sha512": "09e59f1759bf4db8471f02d0aefd8db602b44932a291c05c312b1423796e7a15d1598d3c62a0cec7f083eff8e410fac09363533dc4bd2120914bb9664efea535"
+       },
+       "depends": [
+         "ocaml",
+         "ocamlbuild"
+       ],
+       "build-depends": [
+         "ocamlbuild",
+         "ocamlfind"
+       ]
+     },
+     "uri": {
+       "version": "4.4.0",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-uri/releases/download/v4.4.0/uri-4.4.0.tbz",
+         "sha256": "cdabaf6ef5cd2161e59cc7b74c6e4a68ecb80a9f4e96002e338e1b6bf17adec4"
+       },
+       "depends": [
+         "angstrom",
+         "dune",
+         "ocaml",
+         "stringext"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "uri-sexp": {
+       "version": "4.4.0",
+       "src": {
+         "url": "https://github.com/mirage/ocaml-uri/releases/download/v4.4.0/uri-4.4.0.tbz",
+         "sha256": "cdabaf6ef5cd2161e59cc7b74c6e4a68ecb80a9f4e96002e338e1b6bf17adec4"
+       },
+       "depends": [
+         "dune",
+         "ppx_sexp_conv",
+         "sexplib0",
+         "uri"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "uutf": {
+       "version": "1.0.3",
+       "src": {
+         "url": "https://erratique.ch/software/uutf/releases/uutf-1.0.3.tbz",
+         "sha512": "50cc4486021da46fb08156e9daec0d57b4ca469b07309c508d5a9a41e9dbcf1f32dec2ed7be027326544453dcaf9c2534919395fd826dc7768efc6cc4bfcc9f8"
+       },
+       "depends": [
+         "cmdliner",
+         "ocaml"
+       ],
+       "build-depends": [
+         "ocamlbuild",
+         "ocamlfind",
+         "topkg"
+       ]
+     },
+     "x509": {
+       "version": "0.16.5",
+       "src": {
+         "url": "https://github.com/mirleft/ocaml-x509/releases/download/v0.16.5/x509-0.16.5.tbz",
+         "sha256": "149e25a5fea37f619fb2690bee5c00f01c9dcf31d335f8ffcaab39a7538ccd99"
+       },
+       "depends": [
+         "asn1-combinators",
+         "base64",
+         "cstruct",
+         "domain-name",
+         "dune",
+         "fmt",
+         "gmap",
+         "ipaddr",
+         "logs",
+         "mirage-crypto",
+         "mirage-crypto-ec",
+         "mirage-crypto-pk",
+         "mirage-crypto-rng",
+         "ocaml",
+         "pbkdf",
+         "ptime"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "yojson": {
+       "version": "2.2.2",
+       "src": {
+         "url": "https://github.com/ocaml-community/yojson/releases/download/2.2.2/yojson-2.2.2.tbz",
+         "sha256": "9abfad8c9a79d4723ad2f6448e669c1e68dbfc87cc54a1b7c064b0c90912c595"
+       },
+       "depends": [
+         "dune",
+         "ocaml",
+         "seq"
+       ],
+       "build-depends": [
+         "dune"
+       ]
+     },
+     "zarith": {
+       "version": "1.14",
+       "src": {
+         "url": "https://github.com/ocaml/Zarith/archive/release-1.14.tar.gz",
+         "sha256": "5db9dcbd939153942a08581fabd846d0f3f2b8c67fe68b855127e0472d4d1859"
+       },
+       "depends": [
+         "conf-gmp",
+         "conf-pkg-config",
+         "ocaml",
+         "ocamlfind"
+       ],
+       "build-depends": [
+         "ocamlfind"
+       ]
+     }
+   }
+}


### PR DESCRIPTION
- Remove extra copy of nixpkgs (ocamlformat_0_22_4 is back in main nixpkgs again)
- Use `onix` for dev/prod builds to simplify setup