### PR TITLE
fix(imandra-ai/imandra-web#3593): Informative Slack error messages

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Set up OCaml ${{ matrix.ocaml-compiler }}
-      uses: ocaml/setup-ocaml@v2
+      uses: ocaml/setup-ocaml@v3
       with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
     - run: opam install . --deps-only --with-test


### PR DESCRIPTION
These changes aim to send the most detailed messages to Slack via the logic implicit in Google's Stackdriver.  One of the changes was just to update the GitHub ocaml-setup action, which stopped working with the latest `ubuntu-latest`.

There are multiple ways to indicate to Stackdriver that a log message contains an error worth noting [1].  From a detection perspective, these methods all work as documented.  However, most of these methods lead to anemic textual reporting in Slack [2].

The best solution we've found through experimentation is to always format errors as exceptions (even when they aren't exceptions).  We've also found it better not to set `@type` to
`type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent` in structured logs, which suppresses some details in reporting.

This commit updates `stackdriver_nodejs_format` to
- optionally take `src_name_opt` (which `Util.Logging` can provide)
- always make the message look like a multi-line exception that should trigger Stackdriver (the simple "Error: message" single-line doesn't work).

This allows us to use this function directly when we want to pass along an explicit `Lexing.position` via `[%here]` (`ppx_here`), which is done in a few places.

However, we can at least pass along the source file's name when using the standard `Util.Logging`, which we think is not worth adapting to accept a `Lexing.position`.

[1]: https://cloud.google.com/error-reporting/docs/formatting-error-messages
[2]: https://www.googlecloudcommunity.com/gc/Google-Cloud-s-operations-suite/How-to-show-an-error-title-in-Error-Reporting-slack-messages/m-p/661669